### PR TITLE
feat: add AggregateId helpers and Result utilities; restructure type exports

### DIFF
--- a/src/command/helpers/aggregate-id.ts
+++ b/src/command/helpers/aggregate-id.ts
@@ -1,0 +1,45 @@
+import { v4 } from 'uuid'
+import type { AggregateId, AppError, Result } from '../../types'
+import { err, ok } from '../../utils/result'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function id<T extends string>(type: T, value: string): AggregateId<T> {
+  return { type, value }
+}
+
+export function zeroId<T extends string>(type: T): AggregateId<T> {
+  const uuid = v4()
+  return { type, value: uuid } as AggregateId<T>
+}
+
+export function validateAggregateId(id: AggregateId): Result<void, AppError> {
+  if (!id || typeof id !== 'object') {
+    return err({
+      code: 'INVALID_AGGREGATE_ID',
+      message: 'Aggregate ID is not valid'
+    })
+  }
+
+  const isNotEmpty = id.type !== '' && id.value !== ''
+  if (!isNotEmpty) {
+    return err({
+      code: 'INVALID_AGGREGATE_ID',
+      message: 'Aggregate ID is not valid'
+    })
+  }
+
+  const isUuid = UUID_REGEX.test(id.value)
+  if (!isUuid) {
+    return err({
+      code: 'INVALID_AGGREGATE_ID',
+      message: 'Aggregate ID is not valid uuid'
+    })
+  }
+
+  return ok(undefined)
+}
+
+export function isEqualId(id1: AggregateId, id2: AggregateId): boolean {
+  return id1.type === id2.type && id1.value === id2.value
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export type { Command } from './types/command'
+export { id, zeroId } from './command/helpers/aggregate-id'
+export * from './types'
+export { err, ok, toAsyncResult, toResult } from './utils/result'

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,1 +1,0 @@
-export type Command = { type: string }

--- a/src/types/core/aggregate-id.ts
+++ b/src/types/core/aggregate-id.ts
@@ -1,0 +1,4 @@
+export type AggregateId<T extends string = string> = {
+  readonly type: T
+  readonly value: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './core/aggregate-id'
+export * from './utils/app-error'
+export * from './utils/result'

--- a/src/types/utils/app-error.ts
+++ b/src/types/utils/app-error.ts
@@ -1,0 +1,4 @@
+export type AppError = {
+  code: string
+  message: string
+}

--- a/src/types/utils/result.ts
+++ b/src/types/utils/result.ts
@@ -1,0 +1,13 @@
+export type Ok<T> = {
+  readonly ok: true
+  readonly value: T
+}
+
+export type Err<E> = {
+  readonly ok: false
+  readonly error: E
+}
+
+export type Result<T, E> = Ok<T> | Err<E>
+
+export type AsyncResult<T, E> = Promise<Result<T, E>>

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -1,0 +1,30 @@
+import type { AsyncResult, Err, Ok, Result } from '../types'
+
+export function ok<T>(value: T): Ok<T> {
+  return { ok: true, value }
+}
+
+export function err<E>(error: E): Err<E> {
+  return { ok: false, error }
+}
+
+export function toResult<T>(fn: () => T): Result<T, Error> {
+  try {
+    const value = fn()
+    return ok(value)
+  } catch (e: unknown) {
+    return err(e instanceof Error ? e : new Error(String(e)))
+  }
+}
+
+export async function toAsyncResult<T>(fn: () => Promise<T>): AsyncResult<T, Error> {
+  try {
+    const value = await fn()
+    if (typeof value === 'object' && value !== null && 'ok' in value) {
+      return value as Result<T, Error>
+    }
+    return ok(value)
+  } catch (e: unknown) {
+    return err(e instanceof Error ? e : new Error(String(e)))
+  }
+}

--- a/tests/command/helpers/aggregate-id.test.ts
+++ b/tests/command/helpers/aggregate-id.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  id,
+  isEqualId,
+  validateAggregateId,
+  zeroId
+} from '../../../src/command/helpers/aggregate-id'
+import type { AggregateId } from '../../../src/types'
+
+describe('[command] aggregate id helper functions', () => {
+  describe('id', () => {
+    test('creates aggregate ID with specified type and value', () => {
+      // Arrange
+      const type = 'todo'
+      const value = '123e4567-e89b-12d3-a456-426614174000'
+
+      // Act
+      const res = id(type, value)
+
+      // Assert
+      expect(res.type).toBe(type)
+      expect(res.value).toBe(value)
+    })
+
+    test('preserves exact type parameter in return type', () => {
+      // Arrange
+      const type = 'product'
+      const value = '123e4567-e89b-12d3-a456-426614174000'
+
+      // Act
+      const res = id(type, value)
+
+      // Assert
+      expect(res.type).toBe('product')
+      expect(res.value).toBe(value)
+    })
+
+    test('handles empty string type', () => {
+      // Arrange
+      const type = ''
+      const value = '123e4567-e89b-12d3-a456-426614174000'
+
+      // Act
+      const res = id(type, value)
+
+      // Assert
+      expect(res.type).toBe('')
+      expect(res.value).toBe(value)
+    })
+
+    test('handles empty string value', () => {
+      // Arrange
+      const type = 'todo'
+      const value = ''
+
+      // Act
+      const res = id(type, value)
+
+      // Assert
+      expect(res.type).toBe(type)
+      expect(res.value).toBe('')
+    })
+  })
+
+  describe('zeroId', () => {
+    test('creates aggregate ID with specified type and generated UUID', () => {
+      // Arrange
+      const type = 'todo'
+
+      // Act
+      const res = zeroId(type)
+
+      // Assert
+      expect(res.type).toBe(type)
+      expect(res.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+    })
+
+    test('generates unique UUIDs for multiple calls', () => {
+      // Arrange & Act
+      const id1 = zeroId('todo')
+      const id2 = zeroId('todo')
+
+      // Assert
+      expect(id1.value).not.toBe(id2.value)
+      expect(id1.type).toBe(id2.type)
+    })
+
+    test('preserves exact type parameter in return type', () => {
+      // Arrange
+      const type = 'product'
+
+      // Act
+      const res = zeroId(type)
+
+      // Assert
+      expect(res.type).toBe('product')
+      expect(res.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+    })
+
+    test('handles empty string type', () => {
+      // Arrange
+      const type = ''
+
+      // Act
+      const res = zeroId(type)
+
+      // Assert
+      expect(res.type).toBe('')
+      expect(res.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+    })
+  })
+
+  describe('validateAggregateId', () => {
+    test('returns success for valid aggregate ID', () => {
+      // Arrange
+      const aggregateId = id('todo', '123e4567-e89b-12d3-a456-426614174000')
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toBe(undefined)
+      }
+    })
+
+    test('returns success for valid aggregate ID from zeroId', () => {
+      // Arrange
+      const aggregateId = zeroId('product')
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toBe(undefined)
+      }
+    })
+
+    test('returns error when aggregate ID is null', () => {
+      // Arrange
+      const aggregateId = null
+
+      // Act
+      const res = validateAggregateId(aggregateId as unknown as AggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid')
+      }
+    })
+
+    test('returns error when aggregate ID is undefined', () => {
+      // Arrange
+      const aggregateId = undefined
+
+      // Act
+      const res = validateAggregateId(aggregateId as unknown as AggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid')
+      }
+    })
+
+    test('returns error when aggregate ID is not an object', () => {
+      // Arrange
+      const aggregateId = 'string-instead-of-object'
+
+      // Act
+      const res = validateAggregateId(aggregateId as unknown as AggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid')
+      }
+    })
+
+    test('returns error when aggregate ID type is empty string', () => {
+      // Arrange
+      const aggregateId: AggregateId = { type: '', value: '123e4567-e89b-12d3-a456-426614174000' }
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid')
+      }
+    })
+
+    test('returns error when aggregate ID value is empty string', () => {
+      // Arrange
+      const aggregateId: AggregateId = { type: 'todo', value: '' }
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid')
+      }
+    })
+
+    test('returns error when both type and value are empty strings', () => {
+      // Arrange
+      const aggregateId: AggregateId = { type: '', value: '' }
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid')
+      }
+    })
+
+    test('returns error when value is not a valid UUID', () => {
+      // Arrange
+      const aggregateId = id('todo', 'not-a-uuid')
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid uuid')
+      }
+    })
+
+    test('returns error when value has invalid UUID format with wrong length', () => {
+      // Arrange
+      const aggregateId = id('todo', '123e4567-e89b-12d3-a456-42661417400') // missing one character
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid uuid')
+      }
+    })
+
+    test('returns error when value has invalid UUID format with extra characters', () => {
+      // Arrange
+      const aggregateId = id('todo', '123e4567-e89b-12d3-a456-4266141740000') // extra character
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid uuid')
+      }
+    })
+
+    test('returns error when value has invalid UUID format with missing hyphens', () => {
+      // Arrange
+      const aggregateId = id('todo', '123e4567e89b12d3a456426614174000')
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('INVALID_AGGREGATE_ID')
+        expect(res.error.message).toBe('Aggregate ID is not valid uuid')
+      }
+    })
+
+    test('accepts valid UUID with uppercase characters', () => {
+      // Arrange
+      const aggregateId = id('todo', '123E4567-E89B-12D3-A456-426614174000')
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toBe(undefined)
+      }
+    })
+
+    test('accepts valid UUID with lowercase characters', () => {
+      // Arrange
+      const aggregateId = id('todo', '123e4567-e89b-12d3-a456-426614174000')
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toBe(undefined)
+      }
+    })
+
+    test('accepts valid UUID with mixed case characters', () => {
+      // Arrange
+      const aggregateId = id('todo', '123E4567-e89B-12d3-A456-426614174000')
+
+      // Act
+      const res = validateAggregateId(aggregateId)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toBe(undefined)
+      }
+    })
+  })
+
+  describe('isEqualId', () => {
+    test('returns true for identical aggregate IDs', () => {
+      // Arrange
+      const id1 = id('todo', '123e4567-e89b-12d3-a456-426614174000')
+      const id2 = id('todo', '123e4567-e89b-12d3-a456-426614174000')
+
+      // Act
+      const res = isEqualId(id1, id2)
+
+      // Assert
+      expect(res).toBe(true)
+    })
+
+    test('returns false for different types with same value', () => {
+      // Arrange
+      const id1 = id('todo', '123e4567-e89b-12d3-a456-426614174000')
+      const id2 = id('product', '123e4567-e89b-12d3-a456-426614174000')
+
+      // Act
+      const res = isEqualId(id1, id2)
+
+      // Assert
+      expect(res).toBe(false)
+    })
+
+    test('returns false for same type with different values', () => {
+      // Arrange
+      const id1 = id('todo', '123e4567-e89b-12d3-a456-426614174000')
+      const id2 = id('todo', '987f6543-a21b-34e5-b678-537425285111')
+
+      // Act
+      const res = isEqualId(id1, id2)
+
+      // Assert
+      expect(res).toBe(false)
+    })
+
+    test('returns false for completely different aggregate IDs', () => {
+      // Arrange
+      const id1 = id('todo', '123e4567-e89b-12d3-a456-426614174000')
+      const id2 = id('product', '987f6543-a21b-34e5-b678-537425285111')
+
+      // Act
+      const res = isEqualId(id1, id2)
+
+      // Assert
+      expect(res).toBe(false)
+    })
+
+    test('returns true for IDs created with zeroId and id with same values', () => {
+      // Arrange
+      const zeroIdInstance = zeroId('todo')
+      const idInstance = id('todo', zeroIdInstance.value)
+
+      // Act
+      const res = isEqualId(zeroIdInstance, idInstance)
+
+      // Assert
+      expect(res).toBe(true)
+    })
+
+    test('returns false for different zeroId instances', () => {
+      // Arrange
+      const id1 = zeroId('todo')
+      const id2 = zeroId('todo')
+
+      // Act
+      const res = isEqualId(id1, id2)
+
+      // Assert
+      expect(res).toBe(false)
+    })
+
+    test('handles empty string type comparison', () => {
+      // Arrange
+      const id1 = id('', '123e4567-e89b-12d3-a456-426614174000')
+      const id2 = id('', '123e4567-e89b-12d3-a456-426614174000')
+
+      // Act
+      const res = isEqualId(id1, id2)
+
+      // Assert
+      expect(res).toBe(true)
+    })
+
+    test('handles empty string value comparison', () => {
+      // Arrange
+      const id1 = id('todo', '')
+      const id2 = id('todo', '')
+
+      // Act
+      const res = isEqualId(id1, id2)
+
+      // Assert
+      expect(res).toBe(true)
+    })
+
+    test('handles case sensitivity in UUID values', () => {
+      // Arrange
+      const id1 = id('todo', '123e4567-e89b-12d3-a456-426614174000')
+      const id2 = id('todo', '123E4567-E89B-12D3-A456-426614174000')
+
+      // Act
+      const res = isEqualId(id1, id2)
+
+      // Assert
+      expect(res).toBe(false)
+    })
+  })
+})

--- a/tests/utils/result.test.ts
+++ b/tests/utils/result.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, test } from 'bun:test'
+import type { Ok } from '../../src'
+import { err, ok, toAsyncResult, toResult } from '../../src'
+
+describe('[utils] result utility functions', () => {
+  describe('ok', () => {
+    test('creates successful result with string value', () => {
+      // Arrange
+      const value = 'success'
+
+      // Act
+      const res = ok(value)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      expect(res.value).toBe('success')
+    })
+
+    test('creates successful result with number value', () => {
+      // Arrange
+      const value = 42
+
+      // Act
+      const res = ok(value)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      expect(res.value).toBe(42)
+    })
+
+    test('creates successful result with object value', () => {
+      // Arrange
+      const value = { name: 'test', count: 1 }
+
+      // Act
+      const res = ok(value)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      expect(res.value).toEqual({ name: 'test', count: 1 })
+    })
+
+    test('creates successful result with null value', () => {
+      // Arrange
+      const value = null
+
+      // Act
+      const res = ok(value)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      expect(res.value).toBe(null)
+    })
+
+    test('creates successful result with undefined value', () => {
+      // Arrange
+      const value = undefined
+
+      // Act
+      const res = ok(value)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      expect(res.value).toBe(undefined)
+    })
+  })
+
+  describe('err', () => {
+    test('creates error result with Error object', () => {
+      // Arrange
+      const error = new Error('Something went wrong')
+
+      // Act
+      const res = err(error)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      expect(res.error).toBe(error)
+      expect(res.error.message).toBe('Something went wrong')
+    })
+
+    test('creates error result with string error', () => {
+      // Arrange
+      const error = 'String error'
+
+      // Act
+      const res = err(error)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      expect(res.error).toBe('String error')
+    })
+
+    test('creates error result with custom error object', () => {
+      // Arrange
+      const error = { code: 'CUSTOM_ERROR', message: 'Custom error message' }
+
+      // Act
+      const res = err(error)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      expect(res.error).toEqual({ code: 'CUSTOM_ERROR', message: 'Custom error message' })
+    })
+
+    test('creates error result with null error', () => {
+      // Arrange
+      const error = null
+
+      // Act
+      const res = err(error)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      expect(res.error).toBe(null)
+    })
+  })
+
+  describe('toResult', () => {
+    test('returns success when function executes successfully', () => {
+      // Arrange
+      const fn = () => 'success value'
+
+      // Act
+      const res = toResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toBe('success value')
+      }
+    })
+
+    test('returns success when function returns object', () => {
+      // Arrange
+      const fn = () => ({ result: 'data', count: 5 })
+
+      // Act
+      const res = toResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toEqual({ result: 'data', count: 5 })
+      }
+    })
+
+    test('returns error when function throws Error', () => {
+      // Arrange
+      const fn = () => {
+        throw new Error('Function failed')
+      }
+
+      // Act
+      const res = toResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeInstanceOf(Error)
+        expect(res.error.message).toBe('Function failed')
+      }
+    })
+
+    test('returns error when function throws string', () => {
+      // Arrange
+      const fn = () => {
+        throw 'String error'
+      }
+
+      // Act
+      const res = toResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeInstanceOf(Error)
+        expect(res.error.message).toBe('String error')
+      }
+    })
+
+    test('returns error when function throws number', () => {
+      // Arrange
+      const fn = () => {
+        throw 404
+      }
+
+      // Act
+      const res = toResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeInstanceOf(Error)
+        expect(res.error.message).toBe('404')
+      }
+    })
+
+    test('returns error when function throws null', () => {
+      // Arrange
+      const fn = () => {
+        throw null
+      }
+
+      // Act
+      const res = toResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeInstanceOf(Error)
+        expect(res.error.message).toBe('null')
+      }
+    })
+  })
+
+  describe('toAsyncResult', () => {
+    test('returns success when async function resolves', async () => {
+      // Arrange
+      const fn = async () => 'async success'
+
+      // Act
+      const res = await toAsyncResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toBe('async success')
+      }
+    })
+
+    test('returns success when async function resolves with object', async () => {
+      // Arrange
+      const fn = async () => ({ data: 'test', id: 1 })
+
+      // Act
+      const res = await toAsyncResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toEqual({ data: 'test', id: 1 })
+      }
+    })
+
+    test('returns existing result when function returns result object', async () => {
+      // Arrange
+      const fn = async () => ok('already wrapped')
+
+      // Act
+      const res = await toAsyncResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value).toBe('already wrapped' as unknown as Ok<string>)
+      }
+    })
+
+    test('returns error when async function rejects with Error', async () => {
+      // Arrange
+      const fn = async () => {
+        throw new Error('Async error')
+      }
+
+      // Act
+      const res = await toAsyncResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeInstanceOf(Error)
+        expect(res.error.message).toBe('Async error')
+      }
+    })
+
+    test('returns error when async function rejects with string', async () => {
+      // Arrange
+      const fn = async () => {
+        throw 'Async string error'
+      }
+
+      // Act
+      const res = await toAsyncResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeInstanceOf(Error)
+        expect(res.error.message).toBe('Async string error')
+      }
+    })
+
+    test('returns error when async function rejects with custom object', async () => {
+      // Arrange
+      const fn = async () => {
+        throw { code: 500, message: 'Server error' }
+      }
+
+      // Act
+      const res = await toAsyncResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeInstanceOf(Error)
+        expect(res.error.message).toBe('[object Object]')
+      }
+    })
+
+    test('handles Promise rejection with null', async () => {
+      // Arrange
+      const fn = async () => {
+        throw null
+      }
+
+      // Act
+      const res = await toAsyncResult(fn)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeInstanceOf(Error)
+        expect(res.error.message).toBe('null')
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Introduce `AggregateId` helper functions and `Result` utilities, and reorganize type definitions to strengthen type-safety and developer experience. Public exports are updated accordingly.

## Changes

- Introduce `id`, `zeroId`, `validateAggregateId`, `isEqualId` in `src/command/helpers/aggregate-id.ts`.
- Implement `ok`, `err`, `toResult`, `toAsyncResult` in `src/utils/result.ts`.
- Define `AggregateId` in `src/types/core/aggregate-id.ts`.
- Define `AppError` in `src/types/utils/app-error.ts`.
- Define `Ok`, `Err`, `Result`, `AsyncResult` in `src/types/utils/result.ts`.
- Add type barrel `src/types/index.ts`.
- Update `src/index.ts` to export new helpers and types.
- Delete `src/types/command.ts`.

## Testing

- Unit tests: `tests/command/helpers/aggregate-id.test.ts`, `tests/utils/result.test.ts` (run with `bun run test`)
- Build: `bun run build`

## Related Issues


## Notes

- No breaking changes intended, but imports referencing `src/types/command.ts` should migrate to `src/types/*` barrels.
- Use Bun for scripts (`bun run build`, `bun run test`).