### PR TITLE
feat: introduce core type definitions and exports

### DIFF
--- a/src/types/core/command.ts
+++ b/src/types/core/command.ts
@@ -1,0 +1,27 @@
+import type { AppError } from '../utils/app-error'
+import type { Result } from '../utils/result'
+import type { AggregateId } from './aggregate-id'
+
+export type Command<T = unknown> = {
+  readonly type: string
+  readonly id: AggregateId
+  readonly payload?: T
+}
+
+/**
+ * Represents an empty command type.
+ *
+ * This type is used when there is no specific type to perform.
+ * Typically, it serves as a dummy command when no command is required.
+ */
+export type DummyCommand = {
+  readonly type: ''
+  readonly id: AggregateId
+  readonly payload?: undefined
+}
+
+export type CommandResultPayload = {
+  id: AggregateId
+}
+
+export type CommandResult = Result<CommandResultPayload, AppError>

--- a/src/types/core/domain-event.ts
+++ b/src/types/core/domain-event.ts
@@ -1,0 +1,12 @@
+import type { AggregateId } from './aggregate-id'
+
+export type DomainEvent<T = unknown> = {
+  readonly type: string
+  readonly id: AggregateId
+  readonly payload?: T
+}
+
+export type ExtendedDomainEvent<T extends DomainEvent> = Readonly<T> & {
+  readonly version: number
+  readonly timestamp: Date
+}

--- a/src/types/core/state.ts
+++ b/src/types/core/state.ts
@@ -1,0 +1,14 @@
+import type { AggregateId } from './aggregate-id'
+
+export type State = {
+  readonly type: string
+  readonly id: AggregateId
+}
+
+export type ExtendedState<T extends State> = Readonly<T> & {
+  readonly version: number
+}
+
+export type Snapshot<S extends State> = ExtendedState<S> & {
+  readonly timestamp: Date
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
 export * from './core/aggregate-id'
+export * from './core/command'
+export * from './core/domain-event'
+export * from './core/state'
 export * from './utils/app-error'
 export * from './utils/result'


### PR DESCRIPTION
## Summary

Introduce core CQRS-oriented type definitions (`Command`, `DomainEvent`, `State`) and their extended variants, and expose them via the public types index. This improves type safety and ergonomics without changing runtime behavior.

## Changes

- Add `Command`, `DummyCommand`, and `CommandResult` under `src/types/core/command.ts`
- Add `DomainEvent` and `ExtendedDomainEvent` under `src/types/core/domain-event.ts`
- Add `State`, `ExtendedState`, and `Snapshot` under `src/types/core/state.ts`
- Update `src/types/index.ts` to export the new core types

## Testing

- [x] Unit tests executed

## Related Issues

## Notes

- Purely type-level additions; no runtime logic changes.