### PR TITLE
feat: implement command bus with middleware and type-safe aggregate builder

### DIFF
--- a/src/command/aggregate-builder.ts
+++ b/src/command/aggregate-builder.ts
@@ -1,0 +1,239 @@
+import { produce } from 'immer'
+import type {
+  Aggregate,
+  DeciderMap,
+  EventDecider,
+  EventDeciderFn,
+  Reducer,
+  ReducerFn,
+  ReducerMap
+} from '../types/command'
+import type { Command, DomainEvent, State } from '../types/core'
+import { createAcceptsCommand, createAcceptsEvent } from './helpers/create-accepts'
+
+/**
+ * Internal type representing the accumulated values in the builder
+ */
+type BuilderValue<S extends State, C extends Command, E extends DomainEvent> = {
+  type: S['id']['type']
+  decider: EventDecider<S, C, E> | EventDecider<S, C, E, DeciderMap<S, C>>
+  deciderMap?: DeciderMap<S, C>
+  reducer: Reducer<S, E> | Reducer<S, E, ReducerMap<S, E>>
+  reducerMap?: ReducerMap<S, E>
+}
+
+/**
+ * Builder state types for enforcing correct method call order
+ */
+export type BuilderState = 'initial' | 'hasType' | 'hasDecider' | 'hasReducer' | 'complete'
+
+/**
+ * Public interface for aggregate builder
+ * Provides type-safe fluent API for building aggregates
+ */
+export interface IAggregateBuilder<
+  ST extends BuilderState,
+  S extends State,
+  C extends Command,
+  E extends DomainEvent
+> {
+  readonly _state: ST
+
+  type<T extends string>(
+    this: IAggregateBuilder<'initial', S, C, E>,
+    value: T
+  ): IAggregateBuilder<'hasType', S, C, E>
+
+  decider(
+    this: IAggregateBuilder<'hasType', S, C, E>,
+    value: EventDecider<S, C, E>
+  ): IAggregateBuilder<'hasDecider', S, C, E>
+
+  deciderWithMap(
+    this: IAggregateBuilder<'hasType', S, C, E>,
+    value: EventDecider<S, C, E>,
+    transitionMap: DeciderMap<S, C>
+  ): IAggregateBuilder<'hasDecider', S, C, E>
+
+  reducer(
+    this: IAggregateBuilder<'hasDecider', S, C, E>,
+    value: Reducer<S, E>
+  ): IAggregateBuilder<'complete', S, C, E>
+
+  reducerWithMap(
+    this: IAggregateBuilder<'hasDecider', S, C, E>,
+    value: Reducer<S, E>,
+    transitionMap: ReducerMap<S, E>
+  ): IAggregateBuilder<'complete', S, C, E>
+
+  build(this: IAggregateBuilder<'complete', S, C, E>): Aggregate<S, C, E>
+}
+
+/**
+ * Validates that all required builder values are present
+ */
+function isRequiredBuilderValue<S extends State, C extends Command, E extends DomainEvent>(
+  value: Partial<BuilderValue<S, C, E>>
+): value is BuilderValue<S, C, E> {
+  return value.type !== undefined && value.decider !== undefined && value.reducer !== undefined
+}
+
+/**
+ * Helper to safely convert any decider to EventDeciderFn
+ */
+function createEventDeciderFn<S extends State, C extends Command, E extends DomainEvent>(
+  decider: EventDecider<S, C, E> | EventDecider<S, C, E, DeciderMap<S, C>>
+): EventDeciderFn<S, C, E> {
+  return fromEventDecider(decider as EventDecider<S, C, E>)
+}
+
+/**
+ * Helper to safely convert any reducer to ReducerFn
+ */
+function createReducerFn<S extends State, E extends DomainEvent>(
+  reducer: Reducer<S, E> | Reducer<S, E, ReducerMap<S, E>>
+): ReducerFn<S, E> {
+  return fromReducer(reducer as Reducer<S, E>)
+}
+
+/**
+ * Converts EventDecider object to EventDeciderFn
+ */
+export function fromEventDecider<S extends State, C extends Command, E extends DomainEvent>(
+  deciders: EventDecider<S, C, E>
+): EventDeciderFn<S, C, E> {
+  return ({ ctx, state, command }) => {
+    const decider = deciders[command.type as keyof typeof deciders]
+    if (!decider) {
+      throw new Error(`No decider found for type: ${String(command.type)}`)
+    }
+
+    return decider({ ctx, state, command: command as Extract<C, { type: typeof command.type }> })
+  }
+}
+
+/**
+ * Converts Reducer object to ReducerFn with Immer integration
+ */
+export function fromReducer<S extends State, E extends DomainEvent>(
+  reducers: Reducer<S, E>
+): ReducerFn<S, E> {
+  return ({ ctx, state, event }) => {
+    const reducer = reducers[event.type as keyof typeof reducers]
+    if (!reducer) {
+      throw new Error(`No reducer found for event type: ${String(event.type)}`)
+    }
+
+    // Holds the new typed state if returned by the reducer
+    let updatedTypedState = null
+
+    const updatedState = produce(state, draft => {
+      // The reducer mutates the draft in place. If it returns a value, store it as the typed state.
+      const res = reducer({
+        ctx,
+        state: draft,
+        event: event as Extract<E, { type: typeof event.type }>
+      })
+      if (res !== undefined) {
+        // Validate that the returned value is a proper state object
+        if (res === null || typeof res !== 'object') {
+          throw new Error(
+            `Reducer for event type "${String(event.type)}" returned invalid value: ${typeof res}. ` +
+              'Reducers must return either undefined (to use mutated draft) or a valid state object.'
+          )
+        }
+        updatedTypedState = res
+      }
+    })
+
+    // reducer mutates draft in place, so result is always the new state
+    return updatedTypedState ?? updatedState
+  }
+}
+
+export class AggregateBuilder<
+  ST extends BuilderState,
+  S extends State,
+  C extends Command,
+  E extends DomainEvent
+> {
+  // @ts-expect-error: phantom type to enforce state transitions
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: phantom type to enforce state transitions
+  private readonly _state!: ST
+
+  constructor(private readonly value: Readonly<Partial<BuilderValue<S, C, E>>>) {}
+
+  type(
+    this: AggregateBuilder<'initial', S, C, E>,
+    type: S['id']['type']
+  ): AggregateBuilder<'hasType', S, C, E> {
+    return this.withValue<'hasType', { type: string }>({ type })
+  }
+
+  decider(
+    this: AggregateBuilder<'hasType', S, C, E>,
+    decider: EventDecider<S, C, E>
+  ): AggregateBuilder<'hasDecider', S, C, E> {
+    return this.withValue<'hasDecider', { decider: EventDecider<S, C, E> }>({ decider })
+  }
+
+  deciderWithMap<DM extends DeciderMap<S, C>>(
+    this: AggregateBuilder<'hasType', S, C, E>,
+    decider: EventDecider<S, C, E, DM>,
+    deciderMap: DM
+  ): AggregateBuilder<'hasDecider', S, C, E> {
+    return this.withValue<'hasDecider', { decider: EventDecider<S, C, E, DM>; deciderMap: DM }>({
+      decider,
+      deciderMap
+    })
+  }
+
+  reducer(
+    this: AggregateBuilder<'hasDecider', S, C, E>,
+    reducer: Reducer<S, E>
+  ): AggregateBuilder<'complete', S, C, E> {
+    return this.withValue<'complete', { reducer: Reducer<S, E> }>({ reducer })
+  }
+
+  reducerWithMap<RM extends ReducerMap<S, E>>(
+    this: AggregateBuilder<'hasDecider', S, C, E>,
+    reducer: Reducer<S, E, RM>,
+    reducerMap: RM
+  ): AggregateBuilder<'complete', S, C, E> {
+    return this.withValue<'complete', { reducer: Reducer<S, E, RM>; reducerMap: RM }>({
+      reducer,
+      reducerMap
+    })
+  }
+
+  private withValue<NS extends BuilderState, T extends Partial<BuilderValue<S, C, E>>>(
+    updates: T
+  ): AggregateBuilder<NS, S, C, E> {
+    const newValue = { ...this.value, ...updates }
+    return new AggregateBuilder<NS, S, C, E>(newValue)
+  }
+
+  build(this: AggregateBuilder<'complete', S, C, E>): Aggregate<S, C, E> {
+    if (!isRequiredBuilderValue(this.value)) {
+      throw new Error('Aggregate is not ready to build. Missing required properties.')
+    }
+
+    const deciderMap: DeciderMap<S, C> = this.value.deciderMap ?? ({} as DeciderMap<S, C>)
+    const acceptsCommand = createAcceptsCommand<S, C>(deciderMap)
+
+    const reducerMap: ReducerMap<S, E> = this.value.reducerMap ?? ({} as ReducerMap<S, E>)
+    const acceptsEvent = createAcceptsEvent<S, E>(reducerMap)
+
+    return {
+      type: this.value.type,
+      acceptsCommand,
+      acceptsEvent,
+      decider: createEventDeciderFn(this.value.decider),
+      reducer: createReducerFn(this.value.reducer)
+    }
+  }
+}
+
+export function createAggregate<S extends State, C extends Command, E extends DomainEvent>() {
+  return new AggregateBuilder<'initial', S, C, E>({})
+}

--- a/src/command/command-bus.ts
+++ b/src/command/command-bus.ts
@@ -1,0 +1,43 @@
+import type { AnyAggregate } from '../types/command'
+import type { Command, CommandResult } from '../types/core'
+import type {
+  CommandHandler,
+  CommandHandlerDeps,
+  CommandHandlerMiddleware
+} from '../types/framework'
+import { err } from '../utils/result'
+import { createCommandHandlers } from './command-handler'
+import { validateCommand } from './helpers/validate-command'
+
+export function createCommandBus({
+  deps,
+  aggregates = [],
+  middleware = []
+}: {
+  deps: CommandHandlerDeps
+  aggregates: AnyAggregate[]
+  middleware: CommandHandlerMiddleware[]
+}): CommandHandler {
+  const handlers = createCommandHandlers(deps, aggregates)
+
+  const applyMiddleware = (handler: CommandHandler): CommandHandler => {
+    return middleware.reduceRight<CommandHandler>((next, m) => {
+      return (command: Command) => m(command, next)
+    }, handler)
+  }
+
+  return async (command: Command): CommandResult => {
+    const validated = validateCommand(command)
+    if (!validated.ok) return validated
+
+    const handler = handlers[command.id.type]
+    if (!handler) {
+      return err({
+        code: 'COMMAND_HANDLER_NOT_FOUND',
+        message: `Handler for type ${command.type} not found`
+      })
+    }
+
+    return applyMiddleware(handler)(command)
+  }
+}

--- a/src/command/command-handler.ts
+++ b/src/command/command-handler.ts
@@ -1,0 +1,81 @@
+import type { Aggregate, AnyAggregate } from '../types/command/aggregate'
+import type { AggregateId, Command, CommandResult, DomainEvent, State } from '../types/core'
+import type { CommandHandler, CommandHandlerDeps } from '../types/framework'
+import { err, ok } from '../utils/result'
+import { createApplyEventFnFactory } from './fn/apply-event'
+import { createInitEventFnFactory } from './fn/init-event'
+import { createReplayEventFnFactory } from './fn/replay-event'
+import { createSaveEventFnFactory } from './fn/save-event'
+
+type CommandHandlerFactory<D extends CommandHandlerDeps = CommandHandlerDeps> = (
+  deps: D
+) => CommandHandler
+
+function createCommandHandlerFactory<
+  S extends State,
+  C extends Command,
+  E extends DomainEvent,
+  D extends CommandHandlerDeps
+>(aggregate: Aggregate<S, C, E>): CommandHandlerFactory<D> {
+  return (deps: D) => {
+    const replayFn = createReplayEventFnFactory<S, E, D>(aggregate.reducer)(deps)
+    const initFn = createInitEventFnFactory<S, C, E>(aggregate.decider, aggregate.reducer)()
+    const applyFn = createApplyEventFnFactory<S, C, E>(aggregate.decider, aggregate.reducer)()
+    const saveFn = createSaveEventFnFactory<S, E, D>()(deps)
+
+    // Handles aggregate creation or update based on the incoming command
+    return async (command: Command): CommandResult => {
+      const replayed = await replayFn(command.id as AggregateId<S['id']['type']>)
+      if (!replayed.ok && replayed.error.code !== 'NO_EVENTS_STORED') return replayed
+
+      if (!replayed.ok) {
+        // New aggregate creation flow (init state and apply event)
+        const init = await initFn(command as C)
+        if (!init.ok) return init
+
+        const isAccepted = aggregate.acceptsCommand(init.value.state as S, command as C, 'create')
+        if (!isAccepted) {
+          return err({
+            code: 'COMMAND_NOT_ACCEPTED',
+            message: 'Create command not accepted for initial state'
+          })
+        }
+
+        const saved = await saveFn(init.value.state, init.value.event)
+        if (!saved.ok) return saved
+
+        return ok({ id: init.value.state.id })
+      }
+
+      // Existing aggregate update flow (replay state and apply event)
+      const isAccepted = aggregate.acceptsCommand(replayed.value as S, command as C, 'update')
+      if (!isAccepted) {
+        return err({
+          code: 'COMMAND_NOT_ACCEPTED',
+          message: 'Update command not accepted for replayed state'
+        })
+      }
+
+      const applied = await applyFn(replayed.value, command as C)
+      if (!applied.ok) return applied
+
+      const saved = await saveFn(applied.value.state, applied.value.event)
+      if (!saved.ok) return saved
+
+      return ok({ id: command.id })
+    }
+  }
+}
+
+export function createCommandHandlers(
+  deps: CommandHandlerDeps,
+  aggregates: AnyAggregate[]
+): Record<string, CommandHandler> {
+  const handlers: Record<string, CommandHandler> = {}
+
+  for (const aggregate of aggregates) {
+    handlers[aggregate.type] = createCommandHandlerFactory(aggregate)(deps)
+  }
+
+  return handlers
+}

--- a/src/command/fn/apply-event.ts
+++ b/src/command/fn/apply-event.ts
@@ -1,0 +1,73 @@
+import type {
+  EventDeciderContext,
+  EventDeciderFn,
+  ReducerContext,
+  ReducerFn
+} from '../../types/command'
+import type {
+  Command,
+  DomainEvent,
+  ExtendedDomainEvent,
+  ExtendedState,
+  State
+} from '../../types/core'
+import type { AppError, Result } from '../../types/utils'
+import { err, ok, toResult } from '../../utils/result'
+
+type ApplyEventFn<S extends State, C extends Command, E extends DomainEvent> = (
+  state: ExtendedState<S>,
+  command: C
+) => Result<{ state: ExtendedState<S>; event: ExtendedDomainEvent<E> }, AppError>
+
+export function createApplyEventFnFactory<
+  S extends State,
+  C extends Command,
+  E extends DomainEvent
+>(eventDecider: EventDeciderFn<S, C, E>, reducer: ReducerFn<S, E>): () => ApplyEventFn<S, C, E> {
+  return () => {
+    return (state: ExtendedState<S>, command: C) => {
+      const deciderCtx: EventDeciderContext = {
+        timestamp: new Date()
+      }
+      const eventRes = toResult(() => eventDecider({ ctx: deciderCtx, state, command }))
+      if (!eventRes.ok) {
+        return err({
+          code: 'EVENT_DECIDER_ERROR',
+          message: 'User defined event decider function returned an error',
+          cause: eventRes.error
+        })
+      }
+
+      const event: E = eventRes.value
+      const lastVersion = state.version
+      const newExtendedEvent: ExtendedDomainEvent<E> = {
+        ...event,
+        id: state.id,
+        version: lastVersion + 1,
+        timestamp: new Date()
+      }
+
+      const reducerCtx: ReducerContext = {
+        timestamp: new Date()
+      }
+      const stateRes = toResult(() => reducer({ ctx: reducerCtx, state, event: newExtendedEvent }))
+      if (!stateRes.ok) {
+        return err({
+          code: 'REDUCER_RETURNED_VOID',
+          message: 'Reducer returned void'
+        })
+      }
+
+      const newState: S = stateRes.value
+      const newExtendedState: ExtendedState<S> = {
+        ...newState,
+        version: lastVersion + 1
+      }
+
+      return ok({
+        state: newExtendedState,
+        event: newExtendedEvent
+      })
+    }
+  }
+}

--- a/src/command/fn/init-event.ts
+++ b/src/command/fn/init-event.ts
@@ -1,0 +1,87 @@
+import type {
+  EventDeciderContext,
+  EventDeciderFn,
+  ReducerContext,
+  ReducerFn
+} from '../../types/command'
+import type {
+  Command,
+  DomainEvent,
+  ExtendedDomainEvent,
+  ExtendedState,
+  State
+} from '../../types/core'
+import type { AppError, Result } from '../../types/utils'
+import { err, ok, toResult } from '../../utils/result'
+
+type InitEventFn<S extends State, C extends Command, E extends DomainEvent> = (
+  command: C
+) => Result<{ state: ExtendedState<S>; event: ExtendedDomainEvent<E> }, AppError>
+
+export function createInitEventFnFactory<S extends State, C extends Command, E extends DomainEvent>(
+  eventDecider: EventDeciderFn<S, C, E>,
+  reducer: ReducerFn<S, E>
+): () => InitEventFn<S, C, E> {
+  return () => {
+    return (command: C) => {
+      // Represents the provisional initial state in the event sourcing pattern.
+      // This state is used as the starting point before any events have been applied.
+      // It is constructed using the aggregate ID from the command.
+      const provisionalState: ExtendedState<S> = {
+        ...({ id: command.id } as S),
+        version: 0
+      }
+
+      const deciderCtx: EventDeciderContext = {
+        timestamp: new Date()
+      }
+      const eventRes = toResult(() =>
+        eventDecider({ ctx: deciderCtx, state: provisionalState, command })
+      )
+      if (!eventRes.ok) {
+        return err({
+          code: 'EVENT_DECIDER_ERROR',
+          message: 'Event decider error',
+          cause: eventRes.error
+        })
+      }
+
+      const event: E = eventRes.value
+      const lastVersion = provisionalState.version
+      const newExtendedEvent: ExtendedDomainEvent<E> = {
+        ...event,
+        id: provisionalState.id,
+        version: lastVersion + 1,
+        timestamp: new Date()
+      }
+
+      const reducerCtx: ReducerContext = {
+        timestamp: new Date()
+      }
+      const stateRes = toResult(() =>
+        reducer({
+          ctx: reducerCtx,
+          state: provisionalState,
+          event: newExtendedEvent
+        })
+      )
+      if (!stateRes.ok) {
+        return err({
+          code: 'REDUCER_RETURNED_VOID',
+          message: 'Reducer returned void'
+        })
+      }
+
+      const newState: S = stateRes.value
+      const newExtendedState: ExtendedState<S> = {
+        ...newState,
+        version: lastVersion + 1
+      }
+
+      return ok({
+        state: newExtendedState,
+        event: newExtendedEvent
+      })
+    }
+  }
+}

--- a/src/command/fn/replay-event.ts
+++ b/src/command/fn/replay-event.ts
@@ -1,0 +1,83 @@
+import type { ReducerContext, ReducerFn } from '../../types/command'
+import type { AggregateId, DomainEvent, ExtendedState, Snapshot, State } from '../../types/core'
+import type { CommandHandlerDeps } from '../../types/framework/command-bus'
+import type { AppError, AsyncResult } from '../../types/utils'
+import { err, ok, toAsyncResult, toResult } from '../../utils/result'
+
+export type ReplayEventFn<T extends string, S extends State> = (
+  id: AggregateId<T>
+) => AsyncResult<ExtendedState<S>, AppError>
+
+export function createReplayEventFnFactory<
+  S extends State,
+  E extends DomainEvent,
+  D extends CommandHandlerDeps
+>(reducer: ReducerFn<S, E>): (deps: D) => ReplayEventFn<S['id']['type'], S> {
+  return (deps: D) => {
+    return async (id: AggregateId<S['id']['type']>) => {
+      let state: ExtendedState<S> | null = null
+      let currentVersion = 0
+
+      const snapshot = await toAsyncResult(() =>
+        deps.eventStore.getSnapshot(id as AggregateId<S['id']['type']>)
+      )
+      if (!snapshot.ok) {
+        return err({
+          code: 'SNAPSHOT_CANNOT_BE_LOADED',
+          message: 'Snapshot cannot be loaded',
+          cause: snapshot.error
+        })
+      }
+      if (snapshot.value) {
+        // biome-ignore lint/correctness/noUnusedVariables: timestamp is not used for extended state
+        const { timestamp, ...rest } = snapshot.value as Snapshot<S>
+        currentVersion = rest.version
+        state = rest as ExtendedState<S>
+      }
+
+      const events = await toAsyncResult(() =>
+        deps.eventStore.getEvents<E>(id as AggregateId<S['id']['type']>, currentVersion + 1)
+      )
+      if (!events.ok) {
+        return err({
+          code: 'EVENTS_CANNOT_BE_LOADED',
+          message: 'Events cannot be loaded',
+          cause: events.error
+        })
+      }
+
+      currentVersion += events.value.length
+      if (currentVersion === 0) {
+        return err({
+          code: 'NO_EVENTS_STORED',
+          message: 'No events stored'
+        })
+      }
+
+      const provisionalState: ExtendedState<S> = {
+        ...({ id: id as AggregateId } as S),
+        version: 0
+      }
+
+      let nextState: S = state ?? provisionalState
+      for (const event of events.value) {
+        const ctx: ReducerContext = {
+          timestamp: event.timestamp
+        }
+        const stateRes = toResult(() => reducer({ ctx, state: nextState, event }))
+        if (!stateRes.ok) {
+          return err({
+            code: 'REDUCER_RETURNED_VOID',
+            message: 'Reducer returned void'
+          })
+        }
+        nextState = stateRes.value
+      }
+
+      return ok({
+        ...nextState,
+        version: currentVersion
+      })
+    }
+  }
+}

--- a/src/command/fn/save-event.ts
+++ b/src/command/fn/save-event.ts
@@ -1,0 +1,77 @@
+import type {
+  DomainEvent,
+  ExtendedDomainEvent,
+  ExtendedState,
+  Snapshot,
+  State
+} from '../../types/core'
+import type { CommandHandlerDeps } from '../../types/framework'
+import type { AppError, AsyncResult } from '../../types/utils'
+import { err, ok, toAsyncResult } from '../../utils/result'
+
+export const SNAPSHOT_INTERVAL = 100
+
+export type SaveEventFn<S extends State, E extends DomainEvent> = (
+  state: ExtendedState<S>,
+  event: ExtendedDomainEvent<E>
+) => AsyncResult<void, AppError>
+
+export function createSaveEventFnFactory<
+  S extends State,
+  E extends DomainEvent,
+  D extends CommandHandlerDeps
+>(): (deps: D) => SaveEventFn<S, E> {
+  return (deps: D) => {
+    return async (state: ExtendedState<S>, event: ExtendedDomainEvent<E>) => {
+      if (state.version !== event.version) {
+        return err({
+          code: 'VERSION_MISMATCH',
+          message: `State and event versions mismatch: state version: ${state.version}, event version: ${event.version}`
+        })
+      }
+
+      const gotVersion = await toAsyncResult(() => deps.eventStore.getLastEventVersion(state.id))
+      if (!gotVersion.ok) {
+        return err({
+          code: 'LAST_EVENT_VERSION_CANNOT_BE_LOADED',
+          message: 'Last event version cannot be loaded',
+          cause: gotVersion.error
+        })
+      }
+
+      if (gotVersion.value + 1 !== event.version) {
+        return err({
+          code: 'EVENT_VERSION_CONFLICT',
+          message: `Event version mismatch: expected: ${gotVersion.value + 1}, received: ${event.version}`
+        })
+      }
+
+      if (state.version >= SNAPSHOT_INTERVAL) {
+        const snapshot: Snapshot<S> = {
+          ...state,
+          timestamp: new Date()
+        }
+
+        const savedSnapshot = await toAsyncResult(() => deps.eventStore.saveSnapshot(snapshot))
+        if (!savedSnapshot.ok) {
+          return err({
+            code: 'SNAPSHOT_CANNOT_BE_SAVED',
+            message: 'Snapshot cannot be saved',
+            cause: savedSnapshot.error
+          })
+        }
+      }
+
+      const savedEvents = await toAsyncResult(() => deps.eventStore.saveEvent(event))
+      if (!savedEvents.ok) {
+        return err({
+          code: 'EVENTS_CANNOT_BE_SAVED',
+          message: 'Events cannot be saved',
+          cause: savedEvents.error
+        })
+      }
+
+      return ok(undefined)
+    }
+  }
+}

--- a/src/command/helpers/aggregate-id.ts
+++ b/src/command/helpers/aggregate-id.ts
@@ -1,5 +1,6 @@
 import { v4 } from 'uuid'
-import type { AggregateId, AppError, Result } from '../../types'
+import type { AggregateId } from '../../types/core'
+import type { AppError, Result } from '../../types/utils'
 import { err, ok } from '../../utils/result'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i

--- a/src/command/helpers/create-accepts.ts
+++ b/src/command/helpers/create-accepts.ts
@@ -1,0 +1,44 @@
+import type {
+  AcceptsCommandFn,
+  AcceptsEventFn,
+  ApplyEventType,
+  DeciderMap,
+  ReducerMap
+} from '../../types/command'
+import type { Command, DomainEvent, State } from '../../types/core'
+
+// Checks if a value's type exists in the array associated with the key's type in the map.
+const isMapMatch = <T extends { type: string }, U extends { type: string }>(
+  map: Record<string, string[]>,
+  key: T,
+  val: U
+) => {
+  return (map[key.type] ?? []).includes(val.type)
+}
+
+// Checks if the array associated with the key's type in the map exists but is empty.
+const isMapVoid = <T extends { type: string }>(map: Record<string, string[]>, key: T) => {
+  return map[key.type] !== undefined && map[key.type] !== null && map[key.type]?.length === 0
+}
+
+export const createAcceptsCommand = <S extends State, C extends Command>(
+  map: DeciderMap<S, C>
+): AcceptsCommandFn<S, C> => {
+  return (state: S, command: C, eventType: ApplyEventType) => {
+    // If no map is provided, accept any command for any state.
+    if (Object.keys(map).length === 0) return true
+
+    return eventType === 'create' ? isMapVoid(map, command) : isMapMatch(map, command, state)
+  }
+}
+
+export const createAcceptsEvent = <S extends State, E extends DomainEvent>(
+  map: ReducerMap<S, E>
+): AcceptsEventFn<S, E> => {
+  return (state: S, event: E, eventType: ApplyEventType) => {
+    // If no map is provided, accept any event for any state.
+    if (Object.keys(map).length === 0) return true
+
+    return eventType === 'create' ? isMapVoid(map, event) : isMapMatch(map, event, state)
+  }
+}

--- a/src/command/helpers/validate-command.ts
+++ b/src/command/helpers/validate-command.ts
@@ -1,0 +1,32 @@
+import type { Command } from '../../types/core'
+import type { AppError, Result } from '../../types/utils'
+import { err, ok } from '../../utils/result'
+import { validateAggregateId } from './aggregate-id'
+
+export function validateCommand(command: Command): Result<void, AppError> {
+  const isTypeNotEmpty = command.type && command.type !== ''
+  if (!isTypeNotEmpty) {
+    return err({
+      code: 'INVALID_COMMAND_TYPE',
+      message: 'command type is not valid'
+    })
+  }
+
+  const isValidId = validateAggregateId(command.id)
+  if (!isValidId.ok) return isValidId
+
+  const isPayloadUndefined = typeof command.payload === 'undefined'
+  const isPayloadObject =
+    typeof command.payload === 'object' &&
+    command.payload !== null &&
+    !Array.isArray(command.payload) &&
+    Object.keys(command.payload).length > 0
+  if (!isPayloadUndefined && !isPayloadObject) {
+    return err({
+      code: 'INVALID_COMMAND_PAYLOAD',
+      message: 'Command payload is not valid'
+    })
+  }
+
+  return ok(undefined)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export { id, zeroId } from './command/helpers/aggregate-id'
-export * from './types'
 export { err, ok, toAsyncResult, toResult } from './utils/result'

--- a/src/types/adapter/event-store.ts
+++ b/src/types/adapter/event-store.ts
@@ -1,0 +1,14 @@
+import type { AggregateId } from '../core/aggregate-id'
+import type { DomainEvent, ExtendedDomainEvent } from '../core/domain-event'
+import type { Snapshot, State } from '../core/state'
+
+export interface EventStore {
+  getEvents<E extends DomainEvent>(
+    aggregateId: AggregateId,
+    fromVersion?: number
+  ): Promise<ExtendedDomainEvent<E>[]>
+  getLastEventVersion(aggregateId: AggregateId): Promise<number>
+  saveEvent<E extends DomainEvent>(event: ExtendedDomainEvent<E>): Promise<void>
+  getSnapshot<S extends State>(aggregateId: AggregateId): Promise<Snapshot<S> | null>
+  saveSnapshot<S extends State>(snapshot: Snapshot<S>): Promise<void>
+}

--- a/src/types/adapter/index.ts
+++ b/src/types/adapter/index.ts
@@ -1,0 +1,1 @@
+export * from './event-store'

--- a/src/types/command/accepts-fn.ts
+++ b/src/types/command/accepts-fn.ts
@@ -1,4 +1,4 @@
-import type { Command, DomainEvent, State } from '..'
+import type { Command, DomainEvent, State } from '../core'
 
 export type ApplyEventType = 'create' | 'update'
 

--- a/src/types/command/aggregate.ts
+++ b/src/types/command/aggregate.ts
@@ -1,4 +1,4 @@
-import type { Command, DomainEvent, State } from '../index'
+import type { Command, DomainEvent, State } from '../core'
 import type { AcceptsCommandFn, AcceptsEventFn } from './accepts-fn'
 import type { EventDeciderFn } from './event-decider-fn'
 import type { ReducerFn } from './reducer-fn'

--- a/src/types/command/event-decider-fn.ts
+++ b/src/types/command/event-decider-fn.ts
@@ -1,4 +1,4 @@
-import type { Command, DomainEvent, State } from '..'
+import type { Command, DomainEvent, State } from '../core'
 
 export type EventDeciderContext = {
   readonly timestamp: Date

--- a/src/types/command/event-decider.ts
+++ b/src/types/command/event-decider.ts
@@ -1,4 +1,4 @@
-import type { Command, DomainEvent, State } from '..'
+import type { Command, DomainEvent, State } from '../core'
 import type { DeciderMap, EventDeciderFn } from './event-decider-fn'
 
 export type EventDecider<

--- a/src/types/command/index.ts
+++ b/src/types/command/index.ts
@@ -1,0 +1,6 @@
+export * from './accepts-fn'
+export * from './aggregate'
+export * from './event-decider'
+export * from './event-decider-fn'
+export * from './reducer'
+export * from './reducer-fn'

--- a/src/types/command/reducer-fn.ts
+++ b/src/types/command/reducer-fn.ts
@@ -1,4 +1,4 @@
-import type { DomainEvent, State } from '..'
+import type { DomainEvent, State } from '../core'
 
 export type ReducerContext = {
   readonly timestamp: Date

--- a/src/types/core/command.ts
+++ b/src/types/core/command.ts
@@ -1,5 +1,5 @@
 import type { AppError } from '../utils/app-error'
-import type { Result } from '../utils/result'
+import type { AsyncResult } from '../utils/result'
 import type { AggregateId } from './aggregate-id'
 
 export type Command<T = unknown> = {
@@ -24,4 +24,4 @@ export type CommandResultPayload = {
   id: AggregateId
 }
 
-export type CommandResult = Result<CommandResultPayload, AppError>
+export type CommandResult = AsyncResult<CommandResultPayload, AppError>

--- a/src/types/core/index.ts
+++ b/src/types/core/index.ts
@@ -1,0 +1,4 @@
+export * from './aggregate-id'
+export * from './command'
+export * from './domain-event'
+export * from './state'

--- a/src/types/framework/command-bus.ts
+++ b/src/types/framework/command-bus.ts
@@ -1,0 +1,12 @@
+import type { EventStore } from '../adapter/event-store'
+import type { Command, CommandResult } from '../core/command'
+
+export interface CommandHandlerDeps {
+  eventStore: EventStore
+}
+
+export type CommandHandler = (command: Command) => CommandResult
+
+export type CommandHandlerMiddleware = (command: Command, next: CommandHandler) => CommandResult
+
+export type CommandBus = CommandHandler

--- a/src/types/framework/index.ts
+++ b/src/types/framework/index.ts
@@ -1,0 +1,1 @@
+export * from './command-bus'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,0 @@
-export * from './core/aggregate-id'
-export * from './core/command'
-export * from './core/domain-event'
-export * from './core/state'
-export * from './utils/app-error'
-export * from './utils/result'

--- a/src/types/utils/index.ts
+++ b/src/types/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './app-error'
+export * from './result'

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -1,4 +1,4 @@
-import type { AsyncResult, Err, Ok, Result } from '../types'
+import type { AsyncResult, Err, Ok, Result } from '../types/utils'
 
 export function ok<T>(value: T): Ok<T> {
   return { ok: true, value }

--- a/tests/command/helpers/aggregate-id.test.ts
+++ b/tests/command/helpers/aggregate-id.test.ts
@@ -5,7 +5,7 @@ import {
   validateAggregateId,
   zeroId
 } from '../../../src/command/helpers/aggregate-id'
-import type { AggregateId } from '../../../src/types'
+import type { AggregateId } from '../../../src/types/core'
 
 describe('[command] aggregate id helper functions', () => {
   describe('id', () => {

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -1,7 +1,0 @@
-import { expect, test } from 'bun:test'
-import type { Command } from '../src/index'
-
-test('Command type should have required structure', () => {
-  const command: Command = { type: 'test-command' }
-  expect(command.type).toBe('test-command')
-})

--- a/tests/utils/result.test.ts
+++ b/tests/utils/result.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import type { Ok } from '../../src'
 import { err, ok, toAsyncResult, toResult } from '../../src'
+import type { Ok } from '../../src/types/utils'
 
 describe('[utils] result utility functions', () => {
   describe('ok', () => {


### PR DESCRIPTION
## Summary

Introduce a Command Bus with middleware support and a type-safe Aggregate Builder to streamline CQRS/Event Sourcing workflows. 

## Changes

- Add `src/command/command-bus.ts` with command validation and middleware chaining
- Add `src/command/command-handler.ts` to compose replay/init/apply/save handlers per aggregate
- Add `src/command/aggregate-builder.ts` with a fluent, type-safe API and Immer-backed reducers
- Add `src/command/helpers/aggregate-id.ts` (ID creation, validation, equality helpers)
- Export public APIs via `src/index.ts`
- Add CI workflow `.github/workflows/ci.yml` using Bun (install, lint, build, test)
- Update `package.json` scripts for Bun-based build, lint, and tests; add `immer` and `uuid` dependencies
- Add tests: `tests/utils/result.test.ts`, `tests/command/helpers/aggregate-id.test.ts`

## Testing

- [ ] Unit tests executed

## Related Issues


## Notes

- Command Bus returns a typed error when no handler is found and validates commands before dispatch.
- Aggregate Builder supports both map-based and function variants for deciders/reducers with safe narrowing.
- CI targets pull requests to `main` and uses Bun for all steps.