### PR TITLE
feat: Implement in-memory event store and command bus enhancements

### DIFF
--- a/src/adapter/event-store-in-memory.ts
+++ b/src/adapter/event-store-in-memory.ts
@@ -1,0 +1,48 @@
+import type { EventStore } from '../types/adapter'
+import type { AggregateId, DomainEvent, ExtendedDomainEvent, Snapshot, State } from '../types/core'
+
+export class EventStoreInMemory implements EventStore {
+  constructor(
+    public events: ExtendedDomainEvent<DomainEvent>[] = [],
+    public snapshots: Snapshot<State>[] = []
+  ) {}
+
+  async getEvents<E extends DomainEvent>(
+    aggregateId: AggregateId,
+    fromVersion = 0
+  ): Promise<ExtendedDomainEvent<E>[]> {
+    const events = this.events.filter(
+      e =>
+        e.id.type === aggregateId.type &&
+        e.id.value === aggregateId.value &&
+        e.version >= fromVersion
+    )
+    return events as ExtendedDomainEvent<E>[]
+  }
+
+  async getLastEventVersion(aggregateId: AggregateId): Promise<number> {
+    let maxVersion = 0
+    for (const event of this.events) {
+      if (event.id.type === aggregateId.type && event.id.value === aggregateId.value) {
+        maxVersion = Math.max(maxVersion, event.version)
+      }
+    }
+    return maxVersion
+  }
+
+  async saveEvent<E extends DomainEvent>(event: ExtendedDomainEvent<E>): Promise<void> {
+    this.events.push(event)
+  }
+
+  async getSnapshot<S extends State>(aggregateId: AggregateId): Promise<Snapshot<S> | null> {
+    const snapshot = this.snapshots
+      .filter(s => s.id.type === aggregateId.type && s.id.value === aggregateId.value)
+      .sort((a, b) => b.version - a.version)[0]
+
+    return (snapshot as Snapshot<S>) ?? null
+  }
+
+  async saveSnapshot<S extends State>(snapshot: Snapshot<S>): Promise<void> {
+    this.snapshots.push(snapshot)
+  }
+}

--- a/src/command/command-bus.ts
+++ b/src/command/command-bus.ts
@@ -15,8 +15,8 @@ export function createCommandBus({
   middleware = []
 }: {
   deps: CommandHandlerDeps
-  aggregates: AnyAggregate[]
-  middleware: CommandHandlerMiddleware[]
+  aggregates?: AnyAggregate[]
+  middleware?: CommandHandlerMiddleware[]
 }): CommandHandler {
   const handlers = createCommandHandlers(deps, aggregates)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export { EventStoreInMemory } from './adapter/event-store-in-memory'
 export { id, zeroId } from './command/helpers/aggregate-id'
 export { err, ok, toAsyncResult, toResult } from './utils/result'

--- a/tests/command/aggregate-builder.test.ts
+++ b/tests/command/aggregate-builder.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test } from 'bun:test'
+import { createAggregate, fromReducer } from '../../src/command/aggregate-builder'
+import type { DeciderMap, EventDecider, Reducer, ReducerMap } from '../../src/types/command'
+import type { AggregateId } from '../../src/types/core'
+
+// Test types
+type TestState = {
+  type: 'active' | 'inactive'
+  id: AggregateId<'test'>
+  value: number
+}
+
+type TestCommand =
+  | { type: 'create'; id: AggregateId<'test'>; payload: { value: number } }
+  | { type: 'update'; id: AggregateId<'test'>; payload: { value: number } }
+  | { type: 'deactivate'; id: AggregateId<'test'> }
+
+type TestEvent =
+  | { type: 'created'; id: AggregateId<'test'>; payload: { value: number } }
+  | { type: 'updated'; id: AggregateId<'test'>; payload: { value: number } }
+  | { type: 'deactivated'; id: AggregateId<'test'> }
+
+// Test fixtures
+const testId = (id: string): AggregateId<'test'> => ({ type: 'test', value: id })
+
+const testDecider: EventDecider<TestState, TestCommand, TestEvent> = {
+  create: ({ command }) => ({ type: 'created', id: command.id, payload: command.payload }),
+  update: ({ command }) => ({ type: 'updated', id: command.id, payload: command.payload }),
+  deactivate: ({ command }) => ({ type: 'deactivated', id: command.id })
+}
+
+const testReducer: Reducer<TestState, TestEvent> = {
+  created: ({ state, event }) => {
+    state.type = 'active'
+    state.id = event.id
+    state.value = event.payload.value
+  },
+  updated: ({ state, event }) => {
+    state.value = event.payload.value
+  },
+  deactivated: ({ state }) => {
+    state.type = 'inactive'
+    state.value = 0
+  }
+}
+
+describe('[command] aggregate builder', () => {
+  describe('createAggregate', () => {
+    test('creates aggregate builder instance', () => {
+      // Arrange & Act
+      const builder = createAggregate<TestState, TestCommand, TestEvent>()
+
+      // Assert
+      expect(builder).toBeDefined()
+      expect(typeof builder.type).toBe('function')
+    })
+  })
+
+  describe('aggregate building and functionality', () => {
+    test('builds functioning aggregate with basic configuration', () => {
+      // Arrange & Act
+      const aggregate = createAggregate<TestState, TestCommand, TestEvent>()
+        .type('test')
+        .decider(testDecider)
+        .reducer(testReducer)
+        .build()
+
+      // Assert
+      expect(aggregate).toBeDefined()
+      expect(aggregate.type).toBe('test')
+      expect(typeof aggregate.acceptsCommand).toBe('function')
+      expect(typeof aggregate.acceptsEvent).toBe('function')
+      expect(typeof aggregate.decider).toBe('function')
+      expect(typeof aggregate.reducer).toBe('function')
+    })
+
+    test('builds functioning aggregate with decider and reducer maps', () => {
+      // Arrange
+      const deciderMap: DeciderMap<TestState, TestCommand> = {
+        create: [],
+        update: ['active'],
+        deactivate: ['active', 'inactive']
+      }
+
+      const reducerMap: ReducerMap<TestState, TestEvent> = {
+        created: [],
+        updated: ['active'],
+        deactivated: ['active', 'inactive']
+      }
+
+      // Act
+      const aggregate = createAggregate<TestState, TestCommand, TestEvent>()
+        .type('test')
+        .deciderWithMap(testDecider, deciderMap)
+        .reducerWithMap(testReducer, reducerMap)
+        .build()
+
+      // Assert
+      expect(aggregate.type).toBe('test')
+      expect(typeof aggregate.decider).toBe('function')
+      expect(typeof aggregate.reducer).toBe('function')
+    })
+
+    test('builds functioning aggregate with decider map and reducer', () => {
+      // Arrange
+      const deciderMap: DeciderMap<TestState, TestCommand> = {
+        create: [],
+        update: ['active'],
+        deactivate: ['active', 'inactive']
+      }
+
+      // Act
+      const aggregate = createAggregate<TestState, TestCommand, TestEvent>()
+        .type('test')
+        .deciderWithMap(testDecider, deciderMap)
+        .reducer(testReducer)
+        .build()
+
+      // Assert
+      expect(aggregate.type).toBe('test')
+      expect(typeof aggregate.decider).toBe('function')
+      expect(typeof aggregate.reducer).toBe('function')
+    })
+
+    test('builds functioning aggregate with decider and reducer map', () => {
+      // Arrange
+      const reducerMap: ReducerMap<TestState, TestEvent> = {
+        created: [],
+        updated: ['active'],
+        deactivated: ['active', 'inactive']
+      }
+
+      // Act
+      const aggregate = createAggregate<TestState, TestCommand, TestEvent>()
+        .type('test')
+        .decider(testDecider)
+        .reducerWithMap(testReducer, reducerMap)
+        .build()
+
+      // Assert
+      expect(aggregate.type).toBe('test')
+      expect(typeof aggregate.decider).toBe('function')
+      expect(typeof aggregate.reducer).toBe('function')
+    })
+
+    test('created aggregate processes commands correctly', () => {
+      // Arrange
+      const aggregate = createAggregate<TestState, TestCommand, TestEvent>()
+        .type('test')
+        .decider(testDecider)
+        .reducer(testReducer)
+        .build()
+
+      const command: TestCommand = {
+        type: 'create',
+        id: testId('123'),
+        payload: { value: 42 }
+      }
+
+      const mockState = { type: 'active' as const, id: testId('123'), value: 0 }
+      const ctx = { timestamp: new Date() }
+
+      // Act
+      const event = aggregate.decider({ ctx, state: mockState, command })
+
+      // Assert
+      expect(event).toBeDefined()
+      expect(event.id).toEqual(testId('123'))
+      expect(event.type).toBe('created')
+      if (event.type === 'created') {
+        expect(event.payload).toEqual({ value: 42 })
+      }
+    })
+
+    test('created aggregate processes events correctly', () => {
+      // Arrange
+      const aggregate = createAggregate<TestState, TestCommand, TestEvent>()
+        .type('test')
+        .decider(testDecider)
+        .reducer(testReducer)
+        .build()
+
+      const event: TestEvent = {
+        type: 'created',
+        id: testId('123'),
+        payload: { value: 42 }
+      }
+
+      const initialState = { type: 'inactive' as const, id: testId('123'), value: 0 }
+      const ctx = { timestamp: new Date() }
+
+      // Act
+      const newState = aggregate.reducer({ ctx, state: initialState, event })
+
+      // Assert
+      expect(newState).toBeDefined()
+      expect(newState.type).toBe('active')
+      expect(newState.value).toBe(42)
+    })
+
+    test('preserves state immutability in reducer', () => {
+      // Arrange
+      const aggregate = createAggregate<TestState, TestCommand, TestEvent>()
+        .type('test')
+        .decider(testDecider)
+        .reducer(testReducer)
+        .build()
+
+      const event: TestEvent = {
+        type: 'updated',
+        id: testId('immutable'),
+        payload: { value: 500 }
+      }
+
+      const originalState = { type: 'active' as const, id: testId('immutable'), value: 100 }
+      const ctx = { timestamp: new Date() }
+
+      // Act
+      const newState = aggregate.reducer({ ctx, state: originalState, event })
+
+      // Assert - Original state should remain unchanged
+      expect(originalState.value).toBe(100)
+      // New state should have updated value
+      expect(newState.value).toBe(500)
+      // But they should be different objects
+      expect(newState).not.toBe(originalState)
+    })
+  })
+
+  describe('fromReducer utility', () => {
+    test('converts Reducer object to ReducerFn', () => {
+      // Arrange & Act
+      const reducerFn = fromReducer<TestState, TestEvent>(testReducer)
+
+      // Assert
+      expect(typeof reducerFn).toBe('function')
+    })
+
+    test('converted ReducerFn processes events correctly', () => {
+      // Arrange
+      const reducerFn = fromReducer<TestState, TestEvent>(testReducer)
+
+      const event: TestEvent = {
+        type: 'created',
+        id: testId('456'),
+        payload: { value: 100 }
+      }
+
+      const state = { type: 'inactive' as const, id: testId('456'), value: 0 }
+      const ctx = { timestamp: new Date() }
+
+      // Act
+      const result: TestState = reducerFn({ ctx, state, event })
+
+      // Assert
+      expect(result).toBeDefined()
+      expect(result.type).toBe('active')
+      expect(result.value).toBe(100)
+    })
+
+    test('handles different event types correctly', () => {
+      // Arrange
+      const reducerFn = fromReducer<TestState, TestEvent>(testReducer)
+
+      const updateEvent: TestEvent = {
+        type: 'updated',
+        id: testId('789'),
+        payload: { value: 200 }
+      }
+
+      const state = { type: 'active' as const, id: testId('789'), value: 50 }
+      const ctx = { timestamp: new Date() }
+
+      // Act
+      const result = reducerFn({ ctx, state, event: updateEvent })
+
+      // Assert
+      expect(result).toBeDefined()
+      expect(result.value).toBe(200)
+    })
+
+    test('throws error for unknown event type', () => {
+      // Arrange
+      const reducerFn = fromReducer<TestState, TestEvent>(testReducer)
+
+      const unknownEvent = {
+        type: 'unknown',
+        id: testId('error')
+      }
+
+      const state = { type: 'active' as const, id: testId('error'), value: 0 }
+      const ctx = { timestamp: new Date() }
+
+      // Act & Assert
+      expect(() => {
+        reducerFn({ ctx, state, event: unknownEvent as TestEvent })
+      }).toThrow('No reducer found for event type: unknown')
+    })
+
+    test('handles reducer that returns new state object', () => {
+      // Arrange
+      const replacingReducer: Reducer<TestState, TestEvent> = {
+        created: ({ event }) => ({
+          type: 'active',
+          id: event.id,
+          value: event.payload.value
+        }),
+        updated: ({ state, event }) => {
+          state.value = event.payload.value
+        },
+        deactivated: ({ state }) => {
+          state.type = 'inactive'
+        }
+      }
+
+      const reducerFn = fromReducer<TestState, TestEvent>(replacingReducer)
+
+      const event: TestEvent = {
+        type: 'created',
+        id: testId('replace'),
+        payload: { value: 300 }
+      }
+
+      const state = { type: 'inactive' as const, id: testId('old'), value: 0 }
+      const ctx = { timestamp: new Date() }
+
+      // Act
+      const result = reducerFn({ ctx, state, event })
+
+      // Assert
+      expect(result).toBeDefined()
+      expect(result.type).toBe('active')
+      expect(result.value).toBe(300)
+      expect(result.id).toEqual(testId('replace'))
+    })
+  })
+})

--- a/tests/command/command-bus.test.ts
+++ b/tests/command/command-bus.test.ts
@@ -1,0 +1,678 @@
+import { describe, expect, test } from 'bun:test'
+import { EventStoreInMemory } from '../../src/adapter/event-store-in-memory'
+import { createCommandBus } from '../../src/command/command-bus'
+import { zeroId } from '../../src/command/helpers/aggregate-id'
+import type { AggregateId, Command } from '../../src/types/core'
+import type {
+  CommandHandler,
+  CommandHandlerDeps,
+  CommandHandlerMiddleware
+} from '../../src/types/framework'
+import { counter } from '../fixtures/counter-app/features/counter/counter-aggregate'
+
+function createTestDeps(): CommandHandlerDeps {
+  return {
+    eventStore: new EventStoreInMemory()
+  }
+}
+
+describe('[command] command bus functionality', () => {
+  describe('createCommandBus', () => {
+    test('creates command bus with minimal configuration', () => {
+      // Arrange
+      const deps = createTestDeps()
+
+      // Act
+      const commandBus = createCommandBus({
+        deps,
+        aggregates: [],
+        middleware: []
+      })
+
+      // Assert
+      expect(typeof commandBus).toBe('function')
+    })
+
+    test('creates command bus with full configuration including middleware and services', () => {
+      // Arrange
+      const deps = createTestDeps()
+      const testMiddleware: CommandHandlerMiddleware = async (command, next) => next(command)
+
+      // Act
+      const commandBus = createCommandBus({
+        deps,
+        aggregates: [counter],
+        middleware: [testMiddleware]
+      })
+
+      // Assert
+      expect(typeof commandBus).toBe('function')
+    })
+
+    test('returns function that can execute commands', () => {
+      // Arrange
+      const deps = createTestDeps()
+
+      // Act
+      const commandBus = createCommandBus({ deps })
+
+      // Assert
+      expect(typeof commandBus).toBe('function')
+      expect(commandBus.length).toBe(1) // function should accept one parameter (command)
+    })
+  })
+
+  describe('command execution', () => {
+    describe('command validation', () => {
+      test('executes valid command successfully', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter]
+        })
+
+        const validCommand: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act
+        const result = await commandBus(validCommand)
+
+        // Assert
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          expect(result.value.id).toEqual(validCommand.id)
+        }
+      })
+
+      test('returns error for invalid command structure', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        // missing required fields like 'type'
+        const invalidCommand = {
+          id: zeroId('counter')
+        }
+
+        // Act
+        const result = await commandBus(invalidCommand as Command)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_COMMAND_TYPE')
+        }
+      })
+
+      test('returns error for command with invalid aggregate ID structure', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        const invalidCommand: Command = {
+          type: 'create',
+          id: { invalid: 'structure' } as unknown as AggregateId, // intentionally invalid structure for testing
+          payload: { value: 42 }
+        }
+
+        // Act
+        const result = await commandBus(invalidCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_AGGREGATE_ID')
+        }
+      })
+
+      test('returns error for command with array payload', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        const invalidCommand: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: [1, 2, 3] // arrays are not valid payloads
+        }
+
+        // Act
+        const result = await commandBus(invalidCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+        }
+      })
+
+      test('returns error for command with empty object payload', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        const invalidCommand: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: {} // empty objects are not valid payloads
+        }
+
+        // Act
+        const result = await commandBus(invalidCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+        }
+      })
+
+      test('returns error for command with null payload', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        const invalidCommand = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: null // null is not a valid payload
+        }
+
+        // Act
+        const result = await commandBus(invalidCommand as Command)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+        }
+      })
+
+      test('accepts command without payload', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter]
+        })
+
+        const validCommand: Command = {
+          type: 'increment',
+          id: zeroId('counter')
+          // no payload is valid
+        }
+
+        // Act
+        const result = await commandBus(validCommand)
+
+        // Assert
+        expect(result.ok).toBe(true)
+      })
+
+      test('returns error for invalid command type', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        const invalidCommand: Command = {
+          type: '', // invalid empty type
+          id: zeroId('counter')
+        }
+
+        // Act
+        const result = await commandBus(invalidCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_COMMAND_TYPE')
+        }
+      })
+    })
+
+    describe('command handler resolution', () => {
+      test('executes command when matching handler exists', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter]
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 5 }
+        }
+
+        // Act
+        const result = await commandBus(command)
+
+        // Assert
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          expect(result.value.id).toEqual(command.id)
+        }
+      })
+
+      test('returns error when no handler found for command type', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [] // no aggregates registered
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('nonexistent'),
+          payload: { data: 'test' }
+        }
+
+        // Act
+        const result = await commandBus(command)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('COMMAND_HANDLER_NOT_FOUND')
+        }
+      })
+    })
+
+    describe('middleware application', () => {
+      test('executes command without middleware successfully', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter],
+          middleware: [] // no middleware
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act
+        const result = await commandBus(command)
+
+        // Assert
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          expect(result.value.id).toEqual(command.id)
+        }
+      })
+
+      test('applies single middleware to command execution', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        let middlewareExecuted = false
+
+        const testMiddleware: CommandHandlerMiddleware = async (
+          command: Command,
+          next: CommandHandler
+        ) => {
+          middlewareExecuted = true
+          return next(command)
+        }
+
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter],
+          middleware: [testMiddleware]
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act
+        const result = await commandBus(command)
+
+        // Assert
+        expect(result.ok).toBe(true)
+        expect(middlewareExecuted).toBe(true)
+      })
+
+      test('applies multiple middleware in correct order', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const executionOrder: string[] = []
+
+        const middleware1: CommandHandlerMiddleware = async (
+          command: Command,
+          next: CommandHandler
+        ) => {
+          executionOrder.push('middleware1-before')
+          const result = await next(command)
+          executionOrder.push('middleware1-after')
+          return result
+        }
+
+        const middleware2: CommandHandlerMiddleware = async (
+          command: Command,
+          next: CommandHandler
+        ) => {
+          executionOrder.push('middleware2-before')
+          const result = await next(command)
+          executionOrder.push('middleware2-after')
+          return result
+        }
+
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter],
+          middleware: [middleware1, middleware2]
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act
+        await commandBus(command)
+
+        // Assert
+        expect(executionOrder).toEqual([
+          'middleware1-before',
+          'middleware2-before',
+          'middleware2-after',
+          'middleware1-after'
+        ])
+      })
+
+      test('handles middleware that modifies command', async () => {
+        // Arrange
+        const deps = createTestDeps()
+
+        const modifyingMiddleware: CommandHandlerMiddleware = async (
+          command: Command,
+          next: CommandHandler
+        ) => {
+          const modifiedCommand = {
+            ...command,
+            payload: { count: 999 } // modify payload
+          }
+          return next(modifiedCommand)
+        }
+
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter],
+          middleware: [modifyingMiddleware]
+        })
+
+        const originalCommand: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act
+        const result = await commandBus(originalCommand)
+
+        // Assert
+        expect(result.ok).toBe(true)
+        // The command should be processed with modified payload
+        if (result.ok) {
+          expect(result.value.id).toEqual(originalCommand.id)
+        }
+      })
+
+      test('handles middleware that returns early with error', async () => {
+        // Arrange
+        const deps = createTestDeps()
+
+        const errorMiddleware: CommandHandlerMiddleware = async _ => {
+          return {
+            ok: false,
+            error: {
+              code: 'MIDDLEWARE_ERROR',
+              message: 'Middleware rejected command'
+            }
+          }
+        }
+
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter],
+          middleware: [errorMiddleware]
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act
+        const result = await commandBus(command)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('MIDDLEWARE_ERROR')
+        }
+      })
+
+      test('handles middleware that throws error', async () => {
+        // Arrange
+        const deps = createTestDeps()
+
+        const throwingMiddleware: CommandHandlerMiddleware = async _ => {
+          throw new Error('Middleware threw an error')
+        }
+
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter],
+          middleware: [throwingMiddleware]
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act & Assert
+        await expect(async () => {
+          await commandBus(command)
+        }).toThrow('Middleware threw an error')
+      })
+
+      test('passes next handler correctly through middleware chain', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        let nextHandlerReceived = false
+
+        const verifyingMiddleware: CommandHandlerMiddleware = async (
+          command: Command,
+          next: CommandHandler
+        ) => {
+          nextHandlerReceived = typeof next === 'function'
+          return next(command)
+        }
+
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter],
+          middleware: [verifyingMiddleware]
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act
+        await commandBus(command)
+
+        // Assert
+        expect(nextHandlerReceived).toBe(true)
+      })
+    })
+
+    // TODO: implement domain services functionality
+    // describe('integration with domain services', () => {
+    //   test('creates command bus with domain services configuration', () => {
+    //     // Arrange
+    //     const deps = createTestDeps()
+    //     const testService = createDomainService('test-service', async () => {})
+
+    //     // Act
+    //     const commandBus = createCommandBus({
+    //       deps,
+    //       services: [testService]
+    //     })
+
+    //     // Assert
+    //     expect(typeof commandBus).toBe('function')
+    //   })
+
+    //   test('executes commands when domain services are configured', async () => {
+    //     // Arrange
+    //     const deps = createTestDeps()
+    //     const testService = createDomainService('test-service', async () => {})
+
+    //     const commandBus = createCommandBus({
+    //       deps,
+    //       services: [testService]
+    //     })
+
+    //     const command: Command = {
+    //       type: 'process',
+    //       id: id('test-service', '00000000-0000-0000-0000-000000000001')
+    //     }
+
+    //     // Act
+    //     const result = await commandBus(command)
+
+    //     // Assert
+    //     expect(result.ok).toBe(true)
+    //     if (result.ok) {
+    //       expect(result.value.id).toEqual(command.id)
+    //     }
+    //   })
+    // })
+
+    describe('error handling and result types', () => {
+      test('returns success result for successful command execution', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [counter]
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('counter'),
+          payload: { count: 0 }
+        }
+
+        // Act
+        const result = await commandBus(command)
+
+        // Assert
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          expect(result.value).toHaveProperty('id')
+          expect(result.value.id).toEqual(command.id)
+        }
+      })
+
+      test('returns error result with correct structure for failures', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        const invalidCommand = {}
+
+        // Act
+        const result = await commandBus(invalidCommand as Command)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_COMMAND_TYPE')
+        }
+      })
+
+      test('preserves error details from command validation', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        const invalidCommand: Command = {
+          type: '',
+          id: zeroId('counter')
+        }
+
+        // Act
+        const result = await commandBus(invalidCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_COMMAND_TYPE')
+        }
+      })
+
+      test('preserves error details from aggregate ID validation', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({ deps })
+
+        const invalidCommand: Command = {
+          type: 'create',
+          id: { type: 'counter', value: '' } // invalid empty value
+        }
+
+        // Act
+        const result = await commandBus(invalidCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('INVALID_AGGREGATE_ID')
+        }
+      })
+
+      test('preserves error details from handler execution', async () => {
+        // Arrange
+        const deps = createTestDeps()
+        const commandBus = createCommandBus({
+          deps,
+          aggregates: [] // no handlers available
+        })
+
+        const command: Command = {
+          type: 'create',
+          id: zeroId('nonexistent')
+        }
+
+        // Act
+        const result = await commandBus(command)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('COMMAND_HANDLER_NOT_FOUND')
+        }
+      })
+    })
+  })
+})

--- a/tests/command/command-handler.test.ts
+++ b/tests/command/command-handler.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, test } from 'bun:test'
+import { EventStoreInMemory } from '../../src/adapter/event-store-in-memory'
+import { createCommandHandlers } from '../../src/command/command-handler'
+import { zeroId } from '../../src/command/helpers/aggregate-id'
+import type { EventStore } from '../../src/types/adapter'
+import { counter } from '../fixtures'
+import type { CounterCommand } from '../fixtures/counter-app/features/counter/types'
+
+function createFailingEventStore(
+  operation: 'getEvents' | 'saveEvent' | 'getLastEventVersion'
+): EventStore {
+  const store = new EventStoreInMemory()
+
+  switch (operation) {
+    case 'saveEvent':
+      store.saveEvent = async () => {
+        throw new Error('Save failed')
+      }
+      break
+    case 'getEvents':
+      store.getEvents = async () => {
+        throw new Error('Database error')
+      }
+      break
+    case 'getLastEventVersion':
+      store.getLastEventVersion = async () => {
+        throw new Error('Database error')
+      }
+      break
+  }
+
+  return store
+}
+
+const testId = zeroId('counter')
+
+const createCommand: CounterCommand = {
+  type: 'create',
+  id: testId,
+  payload: { count: 5 }
+}
+
+const incrementCommand: CounterCommand = {
+  type: 'increment',
+  id: testId
+}
+
+describe('[command] command handler', () => {
+  describe('aggregate command handling', () => {
+    describe('new aggregate creation flow', () => {
+      test('creates new aggregate when no events stored', async () => {
+        // Arrange
+        const deps = {
+          eventStore: new EventStoreInMemory()
+        }
+        const handlers = createCommandHandlers(deps, [counter])
+        const commandHandler = handlers[counter.type]!
+
+        // Act
+        const result = await commandHandler(createCommand)
+
+        // Assert
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          expect(result.value.id).toEqual(testId)
+        }
+
+        // Verify event was saved
+        const savedEvents = await deps.eventStore.getEvents(testId)
+        expect(savedEvents.length).toBeGreaterThan(0)
+      })
+
+      test('returns error when init function fails', async () => {
+        // Arrange
+        const deps = {
+          eventStore: new EventStoreInMemory()
+        }
+
+        // Create invalid command that will cause init to fail
+        const invalidCommand = {
+          type: 'invalid' as const,
+          id: testId,
+          payload: {}
+        }
+
+        const handlers = createCommandHandlers(deps, [counter])
+        const commandHandler = handlers[counter.type]!
+
+        // Act
+        const result = await commandHandler(invalidCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+      })
+
+      test('returns error when create command not accepted for initial state', async () => {
+        // Arrange
+        const deps = {
+          eventStore: new EventStoreInMemory()
+        }
+
+        // Create a counter aggregate that rejects the create command
+        const rejectingAggregate = {
+          ...counter,
+          acceptsCommand: () => false
+        }
+
+        const handlers = createCommandHandlers(deps, [rejectingAggregate])
+        const commandHandler = handlers[rejectingAggregate.type]!
+
+        // Act
+        const result = await commandHandler(createCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('COMMAND_NOT_ACCEPTED')
+        }
+      })
+
+      test('returns error when save function fails during creation', async () => {
+        // Arrange
+        const deps = {
+          eventStore: createFailingEventStore('saveEvent')
+        }
+        const handlers = createCommandHandlers(deps, [counter])
+        const commandHandler = handlers[counter.type]!
+
+        // Act
+        const result = await commandHandler(createCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+      })
+    })
+
+    describe('existing aggregate update flow', () => {
+      test('updates existing aggregate when replay succeeds', async () => {
+        // Arrange
+        const deps = {
+          eventStore: new EventStoreInMemory()
+        }
+
+        // First create the aggregate
+        const handlers = createCommandHandlers(deps, [counter])
+        const commandHandler = handlers[counter.type]!
+        await commandHandler(createCommand)
+
+        // Act - Update the existing aggregate
+        const result = await commandHandler(incrementCommand)
+
+        // Assert
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          expect(result.value.id).toEqual(testId)
+        }
+
+        // Verify multiple events were saved
+        const savedEvents = await deps.eventStore.getEvents(testId)
+        expect(savedEvents.length).toBe(2)
+      })
+
+      test('returns error when update command not accepted for replayed state', async () => {
+        // Arrange
+        const deps = {
+          eventStore: new EventStoreInMemory()
+        }
+
+        // First create the aggregate with normal counter
+        const normalHandlers = createCommandHandlers(deps, [counter])
+        const normalHandler = normalHandlers[counter.type]!
+        await normalHandler(createCommand)
+
+        // Create a counter aggregate that rejects update commands
+        const rejectingAggregate = {
+          ...counter,
+          acceptsCommand: () => false
+        }
+
+        const handlers = createCommandHandlers(deps, [rejectingAggregate])
+        const commandHandler = handlers[rejectingAggregate.type]!
+
+        // Act
+        const result = await commandHandler(incrementCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.code).toBe('COMMAND_NOT_ACCEPTED')
+        }
+      })
+
+      test('returns error when apply function fails', async () => {
+        // Arrange
+        const deps = {
+          eventStore: new EventStoreInMemory()
+        }
+
+        // First create the aggregate
+        const handlers = createCommandHandlers(deps, [counter])
+        const commandHandler = handlers[counter.type]!
+        await commandHandler(createCommand)
+
+        // Create invalid command that will cause apply to fail
+        const invalidCommand = {
+          type: 'invalid' as const,
+          id: testId,
+          payload: {}
+        }
+
+        // Act
+        const result = await commandHandler(invalidCommand)!
+
+        // Assert
+        expect(result.ok).toBe(false)
+      })
+
+      test('returns error when save function fails during update', async () => {
+        // Arrange - Create aggregate first with working deps
+        const workingDeps = {
+          eventStore: new EventStoreInMemory()
+        }
+        const workingHandlers = createCommandHandlers(workingDeps, [counter])
+        const workingHandler = workingHandlers[counter.type]!
+        await workingHandler(createCommand)
+
+        // Copy events to failing deps
+        const failingDeps = {
+          eventStore: createFailingEventStore('saveEvent')
+        }
+        const events = await workingDeps.eventStore.getEvents(testId)
+        for (const event of events) {
+          // Add events to failing store before it starts failing
+          const originalSave = failingDeps.eventStore.saveEvent
+          failingDeps.eventStore.saveEvent = workingDeps.eventStore.saveEvent
+          await failingDeps.eventStore.saveEvent(event)
+          failingDeps.eventStore.saveEvent = originalSave
+        }
+
+        const handlers = createCommandHandlers(failingDeps, [counter])
+        const commandHandler = handlers[counter.type]!
+
+        // Act
+        const result = await commandHandler(incrementCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+      })
+    })
+
+    describe('replay error handling', () => {
+      test('returns error when replay fails with non-recoverable error', async () => {
+        // Arrange
+        const deps = {
+          eventStore: createFailingEventStore('getEvents')
+        }
+        const handlers = createCommandHandlers(deps, [counter])
+        const commandHandler = handlers[counter.type]!
+
+        // Act
+        const result = await commandHandler(createCommand)
+
+        // Assert
+        expect(result.ok).toBe(false)
+      })
+    })
+  })
+
+  describe('createCommandHandlers', () => {
+    test('creates handlers for all aggregates and services', () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+
+      // Act
+      const handlers = createCommandHandlers(deps, [counter])
+
+      // Assert
+      expect(handlers).toHaveProperty('counter')
+      expect(typeof handlers[counter.type]).toBe('function')
+    })
+
+    test('returns empty object when no aggregates or services provided', () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+
+      // Act
+      const handlers = createCommandHandlers(deps, [])
+
+      // Assert
+      expect(handlers).toEqual({})
+    })
+
+    test('overrides aggregate handler with service handler when types are duplicated', () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+
+      // Act
+      const handlers = createCommandHandlers(deps, [counter])
+
+      // Assert - Service handler should override the aggregate handler
+      expect(handlers).toHaveProperty('counter')
+      expect(typeof handlers[counter.type]).toBe('function')
+    })
+  })
+})

--- a/tests/command/fn/apply-event.test.ts
+++ b/tests/command/fn/apply-event.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test'
+import { zeroId } from '../../../src'
+import { createApplyEventFnFactory } from '../../../src/command/fn/apply-event'
+import type { ExtendedState } from '../../../src/types/core'
+import { counter, counter2 } from '../../fixtures'
+import type {
+  CounterCommand,
+  CounterState
+} from '../../fixtures/counter-app/features/counter/types'
+
+describe('[command] apply event function', () => {
+  describe('createApplyEventFnFactory', () => {
+    test('should return a function when counter aggregate is provided', () => {
+      // Act
+      const applyEventFn = createApplyEventFnFactory(counter.decider, counter.reducer)()
+
+      // Assert
+      expect(applyEventFn).toBeDefined()
+    })
+
+    test('should return a function when counter2 aggregate is provided', () => {
+      // Act
+      const applyEventFn = createApplyEventFnFactory(counter2.decider, counter2.reducer)()
+
+      // Assert
+      expect(applyEventFn).toBeDefined()
+    })
+  })
+
+  describe('ApplyEventFn', () => {
+    test('should return a result with the new state and event when the command is valid', () => {
+      // Arrange
+      const applyEventFn = createApplyEventFnFactory(counter.decider, counter.reducer)()
+
+      const id = zeroId('counter')
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 0
+      }
+      const command: CounterCommand = {
+        type: 'create',
+        id,
+        payload: { count: 0 }
+      }
+
+      // Act
+      const res = applyEventFn(state, command)
+
+      // Assert
+      expect(res).toBeDefined()
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value.state).toEqual({
+          type: 'active',
+          id,
+          count: 0,
+          version: 1
+        })
+        expect(res.value.event).toEqual({
+          type: 'created',
+          id,
+          payload: { count: 0 },
+          version: 1,
+          timestamp: expect.any(Date)
+        })
+      }
+    })
+
+    test('should return a result with an error when the event decider returns an error', () => {
+      // Arrange
+      const deciderFn = (_: unknown) => {
+        throw new Error('error')
+      }
+      const applyEventFn = createApplyEventFnFactory(deciderFn, counter.reducer)()
+
+      const id = zeroId('counter')
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 0
+      }
+      const command: CounterCommand = {
+        type: 'create',
+        id,
+        payload: { count: 0 }
+      }
+
+      // Act
+      const res = applyEventFn(state, command)
+
+      // Assert
+      expect(res).toBeDefined()
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeDefined()
+        expect(res.error.code).toBe('EVENT_DECIDER_ERROR')
+      }
+    })
+
+    test('should return a result with an error when the reducer returns an error', () => {
+      // Arrange
+      const reducerFn = (_: unknown) => {
+        throw new Error('error')
+      }
+      const applyEventFn = createApplyEventFnFactory(counter.decider, reducerFn)()
+
+      const id = zeroId('counter')
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 0
+      }
+      const command: CounterCommand = {
+        type: 'create',
+        id,
+        payload: { count: 0 }
+      }
+
+      // Act
+      const res = applyEventFn(state, command)
+
+      // Assert
+      expect(res).toBeDefined()
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeDefined()
+        expect(res.error.code).toBe('REDUCER_RETURNED_VOID')
+      }
+    })
+  })
+})

--- a/tests/command/fn/init-event.test.ts
+++ b/tests/command/fn/init-event.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+import { zeroId } from '../../../src'
+import { createInitEventFnFactory } from '../../../src/command/fn/init-event'
+import { counter, counter2 } from '../../fixtures'
+import type { CounterCommand } from '../../fixtures/counter-app/features/counter/types'
+
+describe('[command] init event function', () => {
+  describe('createInitEventFnFactory', () => {
+    test('should return a function when counter aggregate is provided', () => {
+      // Act
+      const initEventFn = createInitEventFnFactory(counter.decider, counter.reducer)()
+
+      // Assert
+      expect(initEventFn).toBeDefined()
+    })
+
+    test('should return a function when counter2 aggregate is provided', () => {
+      // Act
+      const initEventFn = createInitEventFnFactory(counter2.decider, counter2.reducer)()
+
+      // Assert
+      expect(initEventFn).toBeDefined()
+    })
+  })
+
+  describe('InitEventFn', () => {
+    test('should return a result with the new state and event when the command is valid', () => {
+      // Arrange
+      const applyEventFn = createInitEventFnFactory(counter.decider, counter.reducer)()
+
+      const id = zeroId('counter')
+      const command: CounterCommand = {
+        type: 'create',
+        id,
+        payload: { count: 0 }
+      }
+
+      // Act
+      const res = applyEventFn(command)
+
+      // Assert
+      expect(res).toBeDefined()
+      expect(res.ok).toBe(true)
+      if (res.ok) {
+        expect(res.value.state).toEqual({
+          type: 'active',
+          id,
+          count: 0,
+          version: 1
+        })
+        expect(res.value.event).toEqual({
+          type: 'created',
+          id,
+          payload: { count: 0 },
+          version: 1,
+          timestamp: expect.any(Date)
+        })
+      }
+    })
+
+    test('should return a result with an error when the event decider returns an error', () => {
+      // Arrange
+      const deciderFn = (_: unknown) => {
+        throw new Error('error')
+      }
+      const applyEventFn = createInitEventFnFactory(deciderFn, counter.reducer)()
+
+      const id = zeroId('counter')
+      const command: CounterCommand = {
+        type: 'create',
+        id,
+        payload: { count: 0 }
+      }
+
+      // Act
+      const res = applyEventFn(command)
+
+      // Assert
+      expect(res).toBeDefined()
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeDefined()
+        expect(res.error.code).toBe('EVENT_DECIDER_ERROR')
+      }
+    })
+  })
+
+  test('should return a result with an error when the reducer returns an error', () => {
+    // Arrange
+    const reducerFn = (_: unknown) => {
+      throw new Error('error')
+    }
+    const applyEventFn = createInitEventFnFactory(counter.decider, reducerFn)()
+
+    const id = zeroId('counter')
+    const command: CounterCommand = {
+      type: 'create',
+      id,
+      payload: { count: 0 }
+    }
+
+    // Act
+    const res = applyEventFn(command)
+
+    // Assert
+    expect(res).toBeDefined()
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.error).toBeDefined()
+      expect(res.error.code).toBe('REDUCER_RETURNED_VOID')
+    }
+  })
+})

--- a/tests/command/fn/replay-event.test.ts
+++ b/tests/command/fn/replay-event.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from 'bun:test'
+import { EventStoreInMemory } from '../../../src/adapter/event-store-in-memory'
+import { createReplayEventFnFactory } from '../../../src/command/fn/replay-event'
+import { zeroId } from '../../../src/command/helpers/aggregate-id'
+import type { AggregateId } from '../../../src/types/core'
+import { counter, counter2 } from '../../fixtures'
+import type { CounterState } from '../../fixtures/counter-app/features/counter/types'
+
+describe('[command] replay event function', () => {
+  describe('createReplayEventFnFactory', () => {
+    test('should return a function when counter aggregate is provided', () => {
+      // Act
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+
+      // Assert
+      expect(replayEventFn).toBeDefined()
+    })
+
+    test('should return a function when counter2 aggregate is provided', () => {
+      // Act
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const replayEventFn = createReplayEventFnFactory(counter2.reducer)(deps)
+
+      // Assert
+      expect(replayEventFn).toBeDefined()
+    })
+  })
+
+  describe('ReplayEventFn', () => {
+    test('should return a result with the state when the event is found', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+
+      // Act
+      const id = zeroId('counter')
+      await deps.eventStore.saveEvent({
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 1,
+        timestamp: new Date()
+      })
+      const state = await replayEventFn(id)
+
+      // Assert
+      expect(state.ok).toBe(true)
+      if (state.ok) {
+        expect(state.value).toEqual({
+          type: 'active',
+          id,
+          count: 0,
+          version: 1
+        })
+      }
+    })
+
+    test('should return a result with the state when the event and snapshot is found', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+
+      // Act
+      const id = zeroId('counter')
+      await deps.eventStore.saveEvent({
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 1,
+        timestamp: new Date()
+      })
+      await deps.eventStore.saveSnapshot({
+        type: 'active',
+        id,
+        count: 0,
+        version: 1,
+        timestamp: new Date()
+      })
+      const state = await replayEventFn(id)
+
+      // Assert
+      expect(state.ok).toBe(true)
+      if (state.ok) {
+        expect(state.value).toEqual({
+          type: 'active',
+          id,
+          count: 0,
+          version: 1
+        })
+      }
+    })
+
+    test('should return a error when the snapshot can not be loaded', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      deps.eventStore.getSnapshot = async () => {
+        throw new Error('error')
+      }
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+
+      // Act
+      const id = zeroId('counter')
+      await deps.eventStore.saveEvent({
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 1,
+        timestamp: new Date()
+      })
+      const state = await replayEventFn(id)
+
+      // Assert
+      expect(state.ok).toBe(false)
+      if (!state.ok) {
+        expect(state.error).toBeDefined()
+        expect(state.error.code).toBe('SNAPSHOT_CANNOT_BE_LOADED')
+      }
+    })
+
+    test('should return a error when the events can not be loaded', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      deps.eventStore.getEvents = async () => {
+        throw new Error('error')
+      }
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+
+      // Act
+      const id = zeroId('counter')
+      const state = await replayEventFn(id)
+
+      // Assert
+      expect(state.ok).toBe(false)
+      if (!state.ok) {
+        expect(state.error).toBeDefined()
+        expect(state.error.code).toBe('EVENTS_CANNOT_BE_LOADED')
+      }
+    })
+  })
+
+  test('should return a error when no events are stored', async () => {
+    // Arrange
+    const deps = {
+      eventStore: new EventStoreInMemory()
+    }
+    const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+
+    // Act
+    const id = zeroId('counter')
+    const state = await replayEventFn(id)
+
+    // Assert
+    expect(state.ok).toBe(false)
+    if (!state.ok) {
+      expect(state.error).toBeDefined()
+      expect(state.error.code).toBe('NO_EVENTS_STORED')
+    }
+  })
+
+  test('should return a error when the reducer returns void', async () => {
+    // Arrange
+    const deps = {
+      eventStore: new EventStoreInMemory()
+    }
+    const reducer = (_: unknown): CounterState => {
+      throw new Error('error')
+    }
+    const replayEventFn = createReplayEventFnFactory(reducer)(deps)
+
+    // Act
+    const id = zeroId('counter') as AggregateId<'counter'>
+    await deps.eventStore.saveEvent({
+      type: 'created',
+      id,
+      payload: { count: 0 },
+      version: 1,
+      timestamp: new Date()
+    })
+    const state = await replayEventFn(id)
+
+    // Assert
+    expect(state.ok).toBe(false)
+    if (!state.ok) {
+      expect(state.error).toBeDefined()
+      expect(state.error.code).toBe('REDUCER_RETURNED_VOID')
+    }
+  })
+})

--- a/tests/command/fn/save-event.test.ts
+++ b/tests/command/fn/save-event.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from 'bun:test'
+import { EventStoreInMemory, zeroId } from '../../../src'
+import { createSaveEventFnFactory } from '../../../src/command/fn/save-event'
+import type { ExtendedDomainEvent, ExtendedState, Snapshot } from '../../../src/types/core'
+import type { CounterEvent, CounterState } from '../../fixtures/counter-app/features/counter/types'
+
+describe('[command] save event function', () => {
+  describe('createSaveEventFnFactory', () => {
+    test('should return a function when deps is provided', () => {
+      // Act
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const saveEventFn = createSaveEventFnFactory()(deps)
+
+      // Assert
+      expect(saveEventFn).toBeDefined()
+    })
+  })
+
+  describe('SaveEventFn', () => {
+    test('should return ok when the event is saved', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const saveEventFn = createSaveEventFnFactory()(deps)
+
+      // Act
+      const id = zeroId('counter')
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 1
+      }
+      const event: ExtendedDomainEvent<CounterEvent> = {
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 1,
+        timestamp: new Date()
+      }
+      const res = await saveEventFn(state, event)
+
+      // Assert
+      expect(res.ok).toBe(true)
+    })
+
+    test('should return ok when the event and shapshot are saved', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const saveEventFn = createSaveEventFnFactory()(deps)
+
+      const id = zeroId('counter')
+      const createEvent: ExtendedDomainEvent<CounterEvent> = {
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 1,
+        timestamp: new Date()
+      }
+      const incrementEvents: ExtendedDomainEvent<CounterEvent>[] = Array.from(
+        { length: 98 },
+        (_, i) =>
+          ({
+            type: 'incremented',
+            id,
+            version: 2 + i,
+            timestamp: new Date()
+          }) as ExtendedDomainEvent<CounterEvent>
+      )
+      const events = [createEvent, ...incrementEvents]
+      for (const event of events) {
+        await deps.eventStore.saveEvent(event)
+      }
+
+      // Act
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 99,
+        version: 100
+      }
+      const event: ExtendedDomainEvent<CounterEvent> = {
+        type: 'incremented',
+        id,
+        version: 100,
+        timestamp: new Date()
+      }
+      const res = await saveEventFn(state, event)
+      const snapshot = await deps.eventStore.getSnapshot(id)
+
+      // Assert
+      expect(res.ok).toBe(true)
+      expect(snapshot).toEqual({
+        type: 'active',
+        id,
+        count: 99,
+        version: 100,
+        timestamp: expect.any(Date) as Date
+      } as Snapshot<CounterState>)
+    })
+
+    test('should return error when the snapshot can not be saved', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      deps.eventStore.saveSnapshot = async () => {
+        throw new Error('error')
+      }
+      const saveEventFn = createSaveEventFnFactory()(deps)
+
+      const id = zeroId('counter')
+      const createEvent: ExtendedDomainEvent<CounterEvent> = {
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 1,
+        timestamp: new Date()
+      }
+      const incrementEvents: ExtendedDomainEvent<CounterEvent>[] = Array.from(
+        { length: 98 },
+        (_, i) =>
+          ({
+            type: 'incremented',
+            id,
+            version: 2 + i,
+            timestamp: new Date()
+          }) as ExtendedDomainEvent<CounterEvent>
+      )
+      const events = [createEvent, ...incrementEvents]
+      for (const event of events) {
+        await deps.eventStore.saveEvent(event)
+      }
+
+      // Act
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 100
+      }
+      const event: ExtendedDomainEvent<CounterEvent> = {
+        type: 'incremented',
+        id,
+        version: 100,
+        timestamp: new Date()
+      }
+      const res = await saveEventFn(state, event)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeDefined()
+        expect(res.error.code).toBe('SNAPSHOT_CANNOT_BE_SAVED')
+      }
+    })
+
+    test('should return error when the state and event versions mismatch', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const saveEventFn = createSaveEventFnFactory()(deps)
+
+      // Act
+      const id = zeroId('counter')
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 0
+      }
+      const event: ExtendedDomainEvent<CounterEvent> = {
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 1,
+        timestamp: new Date()
+      }
+      const res = await saveEventFn(state, event)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeDefined()
+        expect(res.error.code).toBe('VERSION_MISMATCH')
+      }
+    })
+
+    test('should return error when the last event version can not be loaded', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      deps.eventStore.getLastEventVersion = async () => {
+        throw new Error('error')
+      }
+      const saveEventFn = createSaveEventFnFactory()(deps)
+
+      // Act
+      const id = zeroId('counter')
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 2
+      }
+      const event: ExtendedDomainEvent<CounterEvent> = {
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 2,
+        timestamp: new Date()
+      }
+      const res = await saveEventFn(state, event)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeDefined()
+        expect(res.error.code).toBe('LAST_EVENT_VERSION_CANNOT_BE_LOADED')
+      }
+    })
+
+    test('should return error when the event version is not the next version', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      const saveEventFn = createSaveEventFnFactory()(deps)
+
+      // Act
+      const id = zeroId('counter')
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 2
+      }
+      const event: ExtendedDomainEvent<CounterEvent> = {
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 2,
+        timestamp: new Date()
+      }
+      const res = await saveEventFn(state, event)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeDefined()
+        expect(res.error.code).toBe('EVENT_VERSION_CONFLICT')
+      }
+    })
+
+    test('should return a error when the events can not be loaded', async () => {
+      // Arrange
+      const deps = {
+        eventStore: new EventStoreInMemory()
+      }
+      deps.eventStore.saveEvent = async () => {
+        throw new Error('error')
+      }
+      const saveEventFn = createSaveEventFnFactory()(deps)
+
+      // Act
+      const id = zeroId('counter')
+      const state: ExtendedState<CounterState> = {
+        type: 'active',
+        id,
+        count: 0,
+        version: 1
+      }
+      const event: ExtendedDomainEvent<CounterEvent> = {
+        type: 'created',
+        id,
+        payload: { count: 0 },
+        version: 1,
+        timestamp: new Date()
+      }
+      const res = await saveEventFn(state, event)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error).toBeDefined()
+        expect(res.error.code).toBe('EVENTS_CANNOT_BE_SAVED')
+      }
+    })
+  })
+})

--- a/tests/command/helpers/create-accepts.test.ts
+++ b/tests/command/helpers/create-accepts.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test } from 'bun:test'
+import { zeroId } from '../../../src'
+import {
+  createAcceptsCommand,
+  createAcceptsEvent
+} from '../../../src/command/helpers/create-accepts'
+import type { DeciderMap, ReducerMap } from '../../../src/types/command'
+import type { AggregateId } from '../../../src/types/core'
+
+type TestState =
+  | { type: 'initial'; id: AggregateId }
+  | { type: 'active'; id: AggregateId; value: number }
+  | { type: 'inactive'; id: AggregateId }
+
+type TestCommand =
+  | { type: 'create'; id: AggregateId; payload: { value: number } }
+  | { type: 'update'; id: AggregateId; payload: { value: number } }
+  | { type: 'activate'; id: AggregateId }
+  | { type: 'deactivate'; id: AggregateId }
+
+type TestEvent =
+  | { type: 'created'; id: AggregateId; payload: { value: number } }
+  | { type: 'updated'; id: AggregateId; payload: { value: number } }
+  | { type: 'activated'; id: AggregateId }
+  | { type: 'deactivated'; id: AggregateId }
+
+describe('[command] create accepts function', () => {
+  describe('createAcceptsCommandFn', () => {
+    test('accepts all command and state combinations when empty map is provided', () => {
+      const emptyMap = {} as DeciderMap<TestState, TestCommand>
+      const acceptsCommand = createAcceptsCommand(emptyMap)
+
+      const id = zeroId('test')
+      const initialState: TestState = { type: 'initial', id }
+      const activeState: TestState = { type: 'active', id, value: 10 }
+      const createCommand: TestCommand = { type: 'create', id, payload: { value: 5 } }
+      const updateCommand: TestCommand = { type: 'update', id, payload: { value: 15 } }
+
+      // Test with create event type
+      expect(acceptsCommand(initialState, createCommand, 'create')).toBe(true)
+      expect(acceptsCommand(activeState, createCommand, 'create')).toBe(true)
+
+      // Test with update event type
+      expect(acceptsCommand(initialState, updateCommand, 'update')).toBe(true)
+      expect(acceptsCommand(activeState, updateCommand, 'update')).toBe(true)
+    })
+
+    test('accepts commands with empty array definition for create event type', () => {
+      const deciderMap: DeciderMap<TestState, TestCommand> = {
+        create: [], // create command only allowed during initial creation (no existing state)
+        update: ['active'], // update command only accepted in active state
+        activate: ['initial'], // activate command only accepted in initial state
+        deactivate: ['active'] // deactivate command only accepted in active state
+      }
+
+      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const id = zeroId('test')
+      const createCommand: TestCommand = { type: 'create', id, payload: { value: 5 } }
+      const anyState: TestState = { type: 'active', id, value: 10 }
+
+      // create command has empty array, so it's accepted during creation
+      expect(acceptsCommand(anyState, createCommand, 'create')).toBe(true)
+    })
+
+    test('rejects commands with state array definition for create event type', () => {
+      const deciderMap: DeciderMap<TestState, TestCommand> = {
+        create: [],
+        update: ['active'],
+        activate: ['initial'],
+        deactivate: ['active']
+      }
+
+      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const id = zeroId('test')
+      const updateCommand: TestCommand = { type: 'update', id, payload: { value: 15 } }
+      const anyState: TestState = { type: 'active', id, value: 10 }
+
+      // update command has state array defined, so it's rejected during creation
+      expect(acceptsCommand(anyState, updateCommand, 'create')).toBe(false)
+    })
+
+    test('accepts commands in allowed states for update event type', () => {
+      const deciderMap: DeciderMap<TestState, TestCommand> = {
+        create: [],
+        update: ['active'],
+        activate: ['initial'],
+        deactivate: ['active']
+      }
+
+      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const id = zeroId('test')
+      const activeState: TestState = { type: 'active', id, value: 10 }
+      const initialState: TestState = { type: 'initial', id }
+
+      const updateCommand: TestCommand = { type: 'update', id, payload: { value: 15 } }
+      const activateCommand: TestCommand = { type: 'activate', id }
+
+      // Commands are allowed in their specified states
+      expect(acceptsCommand(activeState, updateCommand, 'update')).toBe(true)
+      expect(acceptsCommand(initialState, activateCommand, 'update')).toBe(true)
+    })
+
+    test('rejects commands in disallowed states for update event type', () => {
+      const deciderMap: DeciderMap<TestState, TestCommand> = {
+        create: [],
+        update: ['active'],
+        activate: ['initial'],
+        deactivate: ['active']
+      }
+
+      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const id = zeroId('test')
+      const activeState: TestState = { type: 'active', id, value: 10 }
+      const initialState: TestState = { type: 'initial', id }
+
+      const updateCommand: TestCommand = { type: 'update', id, payload: { value: 15 } }
+      const activateCommand: TestCommand = { type: 'activate', id }
+
+      // Commands are rejected in non-specified states
+      expect(acceptsCommand(initialState, updateCommand, 'update')).toBe(false)
+      expect(acceptsCommand(activeState, activateCommand, 'update')).toBe(false)
+    })
+
+    test('rejects commands not defined in map for all states and event types', () => {
+      const deciderMap: DeciderMap<TestState, TestCommand> = {
+        create: [],
+        update: ['active'],
+        activate: ['initial'],
+        deactivate: ['active']
+      }
+
+      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const id = zeroId('test')
+      const unknownCommand = { type: 'unknown', id } as unknown as TestCommand
+      const activeState: TestState = { type: 'active', id, value: 10 }
+
+      expect(acceptsCommand(activeState, unknownCommand, 'update')).toBe(false)
+      expect(acceptsCommand(activeState, unknownCommand, 'create')).toBe(false)
+    })
+  })
+
+  describe('createAcceptsEventFn', () => {
+    test('accepts all event and state combinations when empty map is provided', () => {
+      const emptyMap = {} as ReducerMap<TestState, TestEvent>
+      const acceptsEvent = createAcceptsEvent(emptyMap)
+
+      const id = zeroId('test')
+      const initialState: TestState = { type: 'initial', id }
+      const activeState: TestState = { type: 'active', id, value: 10 }
+      const createdEvent: TestEvent = { type: 'created', id, payload: { value: 5 } }
+      const updatedEvent: TestEvent = { type: 'updated', id, payload: { value: 15 } }
+
+      // Test with create event type
+      expect(acceptsEvent(initialState, createdEvent, 'create')).toBe(true)
+      expect(acceptsEvent(activeState, createdEvent, 'create')).toBe(true)
+
+      // Test with update event type
+      expect(acceptsEvent(initialState, updatedEvent, 'update')).toBe(true)
+      expect(acceptsEvent(activeState, updatedEvent, 'update')).toBe(true)
+    })
+
+    test('accepts events with empty array definition for create event type', () => {
+      const reducerMap: ReducerMap<TestState, TestEvent> = {
+        created: [], // created event only during initial creation
+        updated: ['active'], // updated event only applies to active state
+        activated: ['initial'], // activated event only applies to initial state
+        deactivated: ['active'] // deactivated event only applies to active state
+      }
+
+      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const id = zeroId('test')
+      const createdEvent: TestEvent = { type: 'created', id, payload: { value: 5 } }
+      const anyState: TestState = { type: 'active', id, value: 10 }
+
+      // created event has empty array, so it's accepted during creation
+      expect(acceptsEvent(anyState, createdEvent, 'create')).toBe(true)
+    })
+
+    test('rejects events with state array definition for create event type', () => {
+      const reducerMap: ReducerMap<TestState, TestEvent> = {
+        created: [],
+        updated: ['active'],
+        activated: ['initial'],
+        deactivated: ['active']
+      }
+
+      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const id = zeroId('test')
+      const updatedEvent: TestEvent = { type: 'updated', id, payload: { value: 15 } }
+      const anyState: TestState = { type: 'active', id, value: 10 }
+
+      // updated event has state array defined, so it's rejected during creation
+      expect(acceptsEvent(anyState, updatedEvent, 'create')).toBe(false)
+    })
+
+    test('accepts events in allowed states for update event type', () => {
+      const reducerMap: ReducerMap<TestState, TestEvent> = {
+        created: [],
+        updated: ['active'],
+        activated: ['initial'],
+        deactivated: ['active']
+      }
+
+      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const id = zeroId('test')
+      const activeState: TestState = { type: 'active', id, value: 10 }
+      const initialState: TestState = { type: 'initial', id }
+
+      const updatedEvent: TestEvent = { type: 'updated', id, payload: { value: 15 } }
+      const activatedEvent: TestEvent = { type: 'activated', id }
+
+      // Events are allowed in their specified states
+      expect(acceptsEvent(activeState, updatedEvent, 'update')).toBe(true)
+      expect(acceptsEvent(initialState, activatedEvent, 'update')).toBe(true)
+    })
+
+    test('rejects events in disallowed states for update event type', () => {
+      const reducerMap: ReducerMap<TestState, TestEvent> = {
+        created: [],
+        updated: ['active'],
+        activated: ['initial'],
+        deactivated: ['active']
+      }
+
+      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const id = zeroId('test')
+      const activeState: TestState = { type: 'active', id, value: 10 }
+      const initialState: TestState = { type: 'initial', id }
+
+      const updatedEvent: TestEvent = { type: 'updated', id, payload: { value: 15 } }
+      const activatedEvent: TestEvent = { type: 'activated', id }
+
+      // Events are rejected in non-specified states
+      expect(acceptsEvent(initialState, updatedEvent, 'update')).toBe(false)
+      expect(acceptsEvent(activeState, activatedEvent, 'update')).toBe(false)
+    })
+
+    test('correctly handles state transition patterns', () => {
+      const reducerMap: ReducerMap<TestState, TestEvent> = {
+        created: [],
+        updated: ['active'],
+        activated: ['initial'],
+        deactivated: ['active']
+      }
+
+      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const id = zeroId('test')
+      const activatedEvent: TestEvent = { type: 'activated', id }
+      const deactivatedEvent: TestEvent = { type: 'deactivated', id }
+
+      const initialState: TestState = { type: 'initial', id }
+      const activeState: TestState = { type: 'active', id, value: 10 }
+      const inactiveState: TestState = { type: 'inactive', id }
+
+      // initial -> active transition
+      expect(acceptsEvent(initialState, activatedEvent, 'update')).toBe(true)
+      expect(acceptsEvent(activeState, activatedEvent, 'update')).toBe(false)
+      expect(acceptsEvent(inactiveState, activatedEvent, 'update')).toBe(false)
+
+      // active -> inactive transition
+      expect(acceptsEvent(activeState, deactivatedEvent, 'update')).toBe(true)
+      expect(acceptsEvent(initialState, deactivatedEvent, 'update')).toBe(false)
+      expect(acceptsEvent(inactiveState, deactivatedEvent, 'update')).toBe(false)
+    })
+
+    test('rejects events not defined in map for all states and event types', () => {
+      const reducerMap: ReducerMap<TestState, TestEvent> = {
+        created: [],
+        updated: ['active'],
+        activated: ['initial'],
+        deactivated: ['active']
+      }
+
+      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const id = zeroId('test')
+      const unknownEvent = { type: 'unknown', id } as unknown as TestEvent
+      const activeState: TestState = { type: 'active', id, value: 10 }
+
+      expect(acceptsEvent(activeState, unknownEvent, 'update')).toBe(false)
+      expect(acceptsEvent(activeState, unknownEvent, 'create')).toBe(false)
+    })
+
+    test('properly handles null and undefined values in map', () => {
+      // Arrange - intentionally create map with null and undefined values
+      const mapWithNull = {
+        created: [],
+        updated: null, // intentionally set to null
+        activated: undefined, // intentionally set to undefined
+        deactivated: ['active'] // Add required property
+      } as unknown as ReducerMap<TestState, TestEvent>
+
+      const acceptsEvent = createAcceptsEvent(mapWithNull)
+      const id = zeroId('test')
+      const activeState: TestState = { type: 'active', id, value: 10 }
+
+      const updatedEvent: TestEvent = { type: 'updated', id, payload: { value: 15 } }
+      const activatedEvent: TestEvent = { type: 'activated', id }
+
+      // null/undefined cases are handled properly
+      expect(acceptsEvent(activeState, updatedEvent, 'update')).toBe(false)
+      expect(acceptsEvent(activeState, activatedEvent, 'update')).toBe(false)
+    })
+  })
+})

--- a/tests/command/helpers/validate-command.test.ts
+++ b/tests/command/helpers/validate-command.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, test } from 'bun:test'
+import { id, zeroId } from '../../../src/command/helpers/aggregate-id'
+import { validateCommand } from '../../../src/command/helpers/validate-command'
+import type { AggregateId, Command } from '../../../src/types/core'
+
+describe('[command] validate command function', () => {
+  describe('validateCommand', () => {
+    test('returns success for valid command with payload', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command: Command = {
+        type: 'create',
+        id: validId,
+        payload: { value: 42, name: 'test' }
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value).toBe(undefined)
+      }
+    })
+
+    test('returns success for valid command without payload', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command: Command = {
+        type: 'activate',
+        id: validId
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value).toBe(undefined)
+      }
+    })
+
+    test('returns success for valid command with undefined payload', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command: Command = {
+        type: 'deactivate',
+        id: validId,
+        payload: undefined
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value).toBe(undefined)
+      }
+    })
+
+    test('returns error when aggregate ID type is empty', () => {
+      // Arrange
+      const invalidId: AggregateId = { type: '', value: '123e4567-e89b-12d3-a456-426614174000' }
+      const command: Command = {
+        type: 'create',
+        id: invalidId,
+        payload: { value: 42 }
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_AGGREGATE_ID')
+      }
+    })
+
+    test('returns error when aggregate ID value is empty', () => {
+      // Arrange
+      const invalidId: AggregateId = { type: 'test', value: '' }
+      const command: Command = {
+        type: 'create',
+        id: invalidId,
+        payload: { value: 42 }
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_AGGREGATE_ID')
+      }
+    })
+
+    test('returns error when aggregate ID value is not a valid UUID', () => {
+      // Arrange
+      const invalidId: AggregateId = { type: 'test', value: 'not-a-uuid' }
+      const command: Command = {
+        type: 'create',
+        id: invalidId,
+        payload: { value: 42 }
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_AGGREGATE_ID')
+      }
+    })
+
+    test('returns error when command type is empty string', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command: Command = {
+        type: '',
+        id: validId,
+        payload: { value: 42 }
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_TYPE')
+      }
+    })
+
+    test('returns error when payload is null', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command = {
+        type: 'create',
+        id: validId,
+        payload: null
+      }
+
+      // Act
+      const result = validateCommand(command as Command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+      }
+    })
+
+    test('returns error when payload is empty object', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command: Command = {
+        type: 'create',
+        id: validId,
+        payload: {}
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+      }
+    })
+
+    test('returns error when payload is primitive string', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command = {
+        type: 'create',
+        id: validId,
+        payload: 'string-payload'
+      }
+
+      // Act
+      const result = validateCommand(command as Command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+      }
+    })
+
+    test('returns error when payload is primitive number', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command = {
+        type: 'create',
+        id: validId,
+        payload: 42
+      }
+
+      // Act
+      const result = validateCommand(command as Command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+      }
+    })
+
+    test('returns error when payload is boolean', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command = {
+        type: 'create',
+        id: validId,
+        payload: true
+      }
+
+      // Act
+      const result = validateCommand(command as Command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+      }
+    })
+
+    test('returns error when payload is array', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command = {
+        type: 'create',
+        id: validId,
+        payload: [1, 2, 3]
+      }
+
+      // Act
+      const result = validateCommand(command as Command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+      }
+    })
+
+    test('returns success for valid complex nested payload object', () => {
+      // Arrange
+      const validId = zeroId('test')
+      const command: Command = {
+        type: 'create',
+        id: validId,
+        payload: {
+          name: 'test item',
+          metadata: {
+            created: new Date().toISOString(),
+            version: 1
+          },
+          tags: ['important', 'urgent']
+        }
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value).toBe(undefined)
+      }
+    })
+
+    test('handles UUID validation correctly for valid v4 UUID', () => {
+      // Arrange
+      const validUuid = '123e4567-e89b-12d3-a456-426614174000'
+      const validId = id('test', validUuid)
+      const command: Command = {
+        type: 'create',
+        id: validId,
+        payload: { value: 42 }
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(true)
+    })
+
+    test('handles UUID validation correctly for invalid UUID format', () => {
+      // Arrange
+      const invalidUuid = '123e4567-e89b-12d3-a456-42661417400G' // contains 'G' which is invalid
+      const invalidId = id('test', invalidUuid)
+      const command: Command = {
+        type: 'create',
+        id: invalidId,
+        payload: { value: 42 }
+      }
+
+      // Act
+      const result = validateCommand(command)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_AGGREGATE_ID')
+      }
+    })
+
+    test('validates multiple error conditions with aggregate ID taking precedence', () => {
+      // Arrange - Both aggregate ID and command type are invalid
+      const invalidId: AggregateId = { type: '', value: '' }
+      const command = {
+        type: '',
+        id: invalidId,
+        payload: null
+      }
+
+      // Act
+      const result = validateCommand(command as Command)
+
+      // Assert - Should return aggregate ID error first
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_TYPE')
+      }
+    })
+
+    test('validates command type after valid aggregate ID', () => {
+      // Arrange - Valid aggregate ID but invalid command type
+      const validId = zeroId('test')
+      const command = {
+        type: '',
+        id: validId,
+        payload: null
+      }
+
+      // Act
+      const result = validateCommand(command as Command)
+
+      // Assert - Should return command type error
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_TYPE')
+      }
+    })
+
+    test('validates payload after valid aggregate ID and command type', () => {
+      // Arrange - Valid aggregate ID and command type but invalid payload
+      const validId = zeroId('test')
+      const command = {
+        type: 'create',
+        id: validId,
+        payload: null
+      }
+
+      // Act
+      const result = validateCommand(command as Command)
+
+      // Assert - Should return payload error
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_COMMAND_PAYLOAD')
+      }
+    })
+  })
+})

--- a/tests/fixtures/counter-app/features/counter/counter-aggregate.ts
+++ b/tests/fixtures/counter-app/features/counter/counter-aggregate.ts
@@ -1,0 +1,44 @@
+import { createAggregate } from '../../../../../src/command/aggregate-builder'
+import type { EventDecider, Reducer } from '../../../../../src/types/command'
+import type { CounterCommand, CounterEvent, CounterState } from './types'
+
+const decider: EventDecider<CounterState, CounterCommand, CounterEvent> = {
+  create: ({ command }) => {
+    return {
+      type: 'created',
+      id: command.id,
+      payload: { count: command.payload.count }
+    }
+  },
+  increment: ({ command }) => {
+    return {
+      type: 'incremented',
+      id: command.id
+    }
+  },
+  decrement: ({ command }) => {
+    return {
+      type: 'decremented',
+      id: command.id
+    }
+  }
+}
+
+const reducer: Reducer<CounterState, CounterEvent> = {
+  created: ({ state, event }) => {
+    state.type = 'active'
+    state.count = event.payload.count
+  },
+  incremented: ({ state }) => {
+    state.count += 1
+  },
+  decremented: ({ state }) => {
+    state.count -= 1
+  }
+}
+
+export const counter = createAggregate<CounterState, CounterCommand, CounterEvent>()
+  .type('counter')
+  .decider(decider)
+  .reducer(reducer)
+  .build()

--- a/tests/fixtures/counter-app/features/counter/index.ts
+++ b/tests/fixtures/counter-app/features/counter/index.ts
@@ -1,0 +1,2 @@
+export * from './counter-aggregate'
+export * from './types'

--- a/tests/fixtures/counter-app/features/counter/types.ts
+++ b/tests/fixtures/counter-app/features/counter/types.ts
@@ -1,0 +1,19 @@
+import type { AggregateId } from '../../../../../src/types/core'
+
+export type CounterId = AggregateId<'counter'>
+
+export type CounterState = {
+  type: 'active'
+  id: CounterId
+  count: number
+}
+
+export type CounterCommand =
+  | { type: 'create'; id: CounterId; payload: { count: number } }
+  | { type: 'increment'; id: CounterId }
+  | { type: 'decrement'; id: CounterId }
+
+export type CounterEvent =
+  | { type: 'created'; id: CounterId; payload: { count: number } }
+  | { type: 'incremented'; id: CounterId }
+  | { type: 'decremented'; id: CounterId }

--- a/tests/fixtures/counter-app/features/counter2/counter2-aggregate.ts
+++ b/tests/fixtures/counter-app/features/counter2/counter2-aggregate.ts
@@ -1,0 +1,64 @@
+import { createAggregate } from '../../../../../src/command/aggregate-builder'
+import type {
+  DeciderMap,
+  EventDecider,
+  Reducer,
+  ReducerMap
+} from '../../../../../src/types/command'
+import type { CounterCommand, CounterEvent, CounterState } from './types'
+
+const deciderMap = {
+  create: [],
+  increment: ['active'],
+  decrement: ['active']
+} satisfies DeciderMap<CounterState, CounterCommand>
+
+const decider: EventDecider<CounterState, CounterCommand, CounterEvent> = {
+  create: ({ command }) => {
+    return {
+      type: 'created',
+      id: command.id,
+      payload: { count: command.payload.count }
+    }
+  },
+  increment: ({ command }) => {
+    return {
+      type: 'incremented',
+      id: command.id
+    }
+  },
+  decrement: ({ command }) => {
+    return {
+      type: 'decremented',
+      id: command.id
+    }
+  }
+}
+
+const reducerMap = {
+  created: [],
+  incremented: ['active'],
+  decremented: ['active']
+} satisfies ReducerMap<CounterState, CounterEvent>
+
+const reducer: Reducer<CounterState, CounterEvent, typeof reducerMap> = {
+  created: ({ event }) => {
+    return {
+      type: 'active',
+      id: event.id,
+      count: event.payload.count
+    }
+  },
+  incremented: ({ state }) => {
+    state.count += 1
+  },
+  decremented: ({ state }) => {
+    state.count -= 1
+  }
+}
+
+export const counter2 = createAggregate<CounterState, CounterCommand, CounterEvent>()
+  .type('counter')
+  .deciderWithMap(decider, deciderMap)
+  .reducerWithMap(reducer, reducerMap)
+  .build()

--- a/tests/fixtures/counter-app/features/counter2/index.ts
+++ b/tests/fixtures/counter-app/features/counter2/index.ts
@@ -1,0 +1,2 @@
+export * from './counter2-aggregate'
+export * from './types'

--- a/tests/fixtures/counter-app/features/counter2/types.ts
+++ b/tests/fixtures/counter-app/features/counter2/types.ts
@@ -1,0 +1,19 @@
+import type { AggregateId } from '../../../../../src/types/core'
+
+export type CounterId = AggregateId<'counter'>
+
+export type CounterState = {
+  type: 'active'
+  id: CounterId
+  count: number
+}
+
+export type CounterCommand =
+  | { type: 'create'; id: CounterId; payload: { count: number } }
+  | { type: 'increment'; id: CounterId }
+  | { type: 'decrement'; id: CounterId }
+
+export type CounterEvent =
+  | { type: 'created'; id: CounterId; payload: { count: number } }
+  | { type: 'incremented'; id: CounterId }
+  | { type: 'decremented'; id: CounterId }

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -1,0 +1,2 @@
+export * from './counter-app/features/counter/counter-aggregate'
+export * from './counter-app/features/counter2/counter2-aggregate'


### PR DESCRIPTION
## Summary

Introduce an in-memory event store adapter and enhance the command bus to support optional aggregates and middleware. Export the adapter from the library entry point and add comprehensive unit tests covering command flow, aggregate building, helpers, and persistence behavior.

## Changes

- Add `src/adapter/event-store-in-memory.ts` implementing `EventStoreInMemory`
- Update `src/index.ts` to export `EventStoreInMemory`
- Enhance `src/command/command-bus.ts` to accept optional `aggregates` and `middleware`
- Add unit tests:
  - `tests/command/aggregate-builder.test.ts`
  - `tests/command/command-bus.test.ts`
  - `tests/command/command-handler.test.ts`
  - `tests/command/fn/save-event.test.ts`
  - `tests/command/helpers/create-accepts.test.ts`
  - `tests/command/helpers/validate-command.test.ts`
- Add fixtures for counter example:
  - `tests/fixtures/counter-app/**`
  - `tests/fixtures/index.ts`

## Testing

- [x] Unit tests executed

## Notes

- No breaking changes: `createCommandBus` now treats `aggregates` and `middleware` as optional.
- Sets up groundwork for future domain services integration.