### PR TITLE
feat: Add event reactor types, read model store, and event bus

### DIFF
--- a/src/types/adapter/event-dispatcher.ts
+++ b/src/types/adapter/event-dispatcher.ts
@@ -1,0 +1,5 @@
+import type { Command } from '../core'
+
+export interface CommandDispatcher {
+  dispatch(command: Command): Promise<void>
+}

--- a/src/types/adapter/index.ts
+++ b/src/types/adapter/index.ts
@@ -1,1 +1,3 @@
+export * from './event-dispatcher'
 export * from './event-store'
+export * from './read-model-store'

--- a/src/types/adapter/read-model-store.ts
+++ b/src/types/adapter/read-model-store.ts
@@ -1,0 +1,49 @@
+import type { ReadModel } from '../core'
+
+export type ReadModelMap = Record<string, ReadModel>
+
+export type GetListOptions<T extends ReadModel> = {
+  filter?: FilterCondition<T>[]
+  sort?: SortOption<T>
+  range?: RangeOption
+}
+
+export type FilterCondition<T> = {
+  by: keyof T & string
+  operator:
+    | 'eq'
+    | 'ne'
+    | 'gt'
+    | 'gte'
+    | 'lt'
+    | 'lte'
+    | 'in'
+    | 'nin'
+    | 'contains'
+    | 'startsWith'
+    | 'endsWith'
+  value: T[keyof T] | T[keyof T][]
+}
+
+export type SortOption<T> = {
+  by: keyof T & string
+  order: 'asc' | 'desc'
+}
+
+export type RangeOption = {
+  limit: number
+  offset: number
+}
+
+export type QueryOption<T extends ReadModel> = {
+  filter?: FilterCondition<T>[]
+  sort?: SortOption<T>
+  range?: RangeOption
+}
+
+export interface ReadModelStore {
+  findMany<T extends ReadModel>(type: T['type'], options: QueryOption<T>): Promise<T[]>
+  findById<T extends ReadModel>(type: T['type'], id: string): Promise<T | null>
+  save<T extends ReadModel>(model: T): Promise<void>
+  delete<T extends ReadModel>(model: T): Promise<void>
+}

--- a/src/types/core/index.ts
+++ b/src/types/core/index.ts
@@ -1,4 +1,5 @@
 export * from './aggregate-id'
 export * from './command'
 export * from './domain-event'
+export * from './read-model'
 export * from './state'

--- a/src/types/core/read-model.ts
+++ b/src/types/core/read-model.ts
@@ -1,0 +1,4 @@
+export type ReadModel = {
+  readonly type: string
+  readonly id: string
+}

--- a/src/types/event/event-reactor.ts
+++ b/src/types/event/event-reactor.ts
@@ -1,0 +1,12 @@
+import type { Command, DomainEvent, ReadModel } from '../core'
+import type { PolicyFn } from './policy-fn'
+import type { ProjectionFn } from './projection-fn'
+
+export type EventReactor<C extends Command, E extends DomainEvent, RM extends ReadModel> = {
+  type: C['id']['type']
+  policy: PolicyFn<E, C>
+  projection: ProjectionFn<E, RM>
+}
+
+// biome-ignore lint: To enable a generic EventReactor type for utility and type inference purposes.
+export type AnyEventReactor = EventReactor<any, any, any>

--- a/src/types/event/index.ts
+++ b/src/types/event/index.ts
@@ -1,0 +1,5 @@
+export * from './event-reactor'
+export * from './policy'
+export * from './policy-fn'
+export * from './projection'
+export * from './projection-fn'

--- a/src/types/event/policy-fn.ts
+++ b/src/types/event/policy-fn.ts
@@ -1,0 +1,18 @@
+import type { Command, DomainEvent } from '../core'
+
+export type PolicyContext = {
+  readonly timestamp: Date
+}
+
+export type PolicyMap<E extends DomainEvent, C extends Command> = {
+  [K in E['type']]: C['type'][]
+}
+
+export type PolicyParams<E extends DomainEvent> = {
+  ctx: PolicyContext
+  event: E
+}
+
+export type PolicyFn<E extends DomainEvent, C extends Command> = (
+  params: PolicyParams<E>
+) => C | null

--- a/src/types/event/policy.ts
+++ b/src/types/event/policy.ts
@@ -1,0 +1,14 @@
+import type { Command, DomainEvent } from '../core'
+import type { PolicyFn, PolicyMap } from './policy-fn'
+
+export type Policy<E extends DomainEvent, C extends Command, PM extends PolicyMap<E, C> = never> = [
+  PM
+] extends [never]
+  ? {
+      [K in E['type']]: PolicyFn<Extract<E, { type: K }>, C>
+    }
+  : {
+      [K in keyof PM]: PM[K][number] extends never
+        ? PolicyFn<Extract<E, { type: K }>, never>
+        : PolicyFn<Extract<E, { type: K }>, Extract<C, { type: PM[K][number] }>>
+    }

--- a/src/types/event/projection-fn.ts
+++ b/src/types/event/projection-fn.ts
@@ -1,0 +1,29 @@
+import type { DomainEvent, ReadModel } from '../core'
+
+export type ProjectionCtx = {
+  readonly timestamp: Date
+}
+
+type ProjectionMapValue<E extends DomainEvent, RM extends ReadModel> = {
+  readModel: RM['type']
+  where?: (e: E) => Partial<RM>
+}
+
+export type ProjectionMap<E extends DomainEvent, RM extends ReadModel> = {
+  [K in E['type']]: ProjectionMapValue<E, RM>[]
+}
+
+export type ProjectionParams<E extends DomainEvent, RM extends ReadModel> = {
+  ctx: ProjectionCtx
+  event: E
+  readModel: RM
+}
+
+export type ProjectionFn<E extends DomainEvent, RM extends ReadModel> = (
+  params: ProjectionParams<E, RM>
+) => RM
+
+// This function may either mutate the draftreadModel directly (via Immer) and return nothing, or return a newreadModel object entirely.
+// The union `RM | void` intentionally captures both behaviors.
+// biome-ignore lint/suspicious/noConfusingVoidType: ''
+export type MutateOrReplace<RM extends ReadModel> = RM | void

--- a/src/types/event/projection.ts
+++ b/src/types/event/projection.ts
@@ -1,0 +1,15 @@
+import type { Draft } from 'immer'
+import type { DomainEvent, ReadModel } from '../core'
+import type { MutateOrReplace, ProjectionMap, ProjectionParams } from './projection-fn'
+
+export type Projection<
+  E extends DomainEvent,
+  RM extends ReadModel,
+  PM extends ProjectionMap<E, RM>
+> = {
+  [K in keyof PM]: {
+    [VT in PM[K][number]['readModel']]: (
+      params: ProjectionParams<Extract<E, { type: K }>, Draft<Extract<RM, { type: VT }>>>
+    ) => MutateOrReplace<Extract<RM, { type: VT }>>
+  }
+}

--- a/src/types/framework/event-bus.ts
+++ b/src/types/framework/event-bus.ts
@@ -1,0 +1,13 @@
+import type { CommandDispatcher } from '../adapter/event-dispatcher'
+import type { ReadModelStore } from '../adapter/read-model-store'
+import type { DomainEvent, ExtendedDomainEvent } from '../core'
+import type { AppError, AsyncResult } from '../utils'
+
+export interface EventHandlerDeps {
+  readModelStore: ReadModelStore
+  commandDispatcher: CommandDispatcher
+}
+
+export type EventHandler = (event: ExtendedDomainEvent<DomainEvent>) => AsyncResult<void, AppError>
+
+export type EventBus = EventHandler

--- a/src/types/framework/index.ts
+++ b/src/types/framework/index.ts
@@ -1,1 +1,2 @@
 export * from './command-bus'
+export * from './event-bus'


### PR DESCRIPTION
## Summary

Foundational types for event-driven handling across the library, including event reactors (policies and projections), a read model store interface and query types, and an event bus handler contract. It formalizes how domain events can trigger commands and update read models in a type-safe manner.

## Changes

- Add `src/types/adapter/event-dispatcher.ts`: `CommandDispatcher` interface for dispatching commands.
- Add `src/types/adapter/read-model-store.ts`: `ReadModelStore` interface and query types (`FilterCondition`, `SortOption`, `RangeOption`, `QueryOption`).
- Update `src/types/adapter/index.ts`: export `event-dispatcher` and `read-model-store`.
- Add `src/types/core/read-model.ts`: base `ReadModel` type; update `src/types/core/index.ts` to export it.
- Add `src/types/event/event-reactor.ts`: `EventReactor` and `AnyEventReactor` types binding policies and projections to command and read model types.
- Add `src/types/event/policy-fn.ts`: `PolicyFn`, `PolicyContext`, `PolicyMap`, `PolicyParams`.
- Add `src/types/event/policy.ts`: `Policy` mapped type to define event-to-command policy per event type.
- Add `src/types/event/projection-fn.ts`: `ProjectionFn`, `ProjectionMap`, `ProjectionCtx`, `ProjectionParams`, and `MutateOrReplace`.
- Add `src/types/event/projection.ts`: `Projection` mapped type using `immer` `Draft` for ergonomic read model updates.
- Add `src/types/event/index.ts`: central exports for event types.
- Add `src/types/framework/event-bus.ts`: `EventHandlerDeps`, `EventHandler`, and `EventBus` type.
- Update `src/types/framework/index.ts`: export `event-bus`.

## Testing

- [x] Unit tests executed

Manual checks:
- Verified type compatibility and exports across `types/*` modules.
- Ensured `event` types compose with `core` and `adapter` exports.

## Related Issues


## Notes

- `Projection` relies on `immer` `Draft` in type positions; ensure `immer` is available to consumers for type support.
- This change is type-only and does not introduce runtime behavior by itself.