### PR TITLE
feat: implement event handling and read model projection

### DIFF
--- a/src/adapter/command-dispatcher-mock.ts
+++ b/src/adapter/command-dispatcher-mock.ts
@@ -1,0 +1,19 @@
+import type { CommandDispatcher } from '../types/adapter'
+import type { Command } from '../types/core'
+
+export class CommandDispatcherMock implements CommandDispatcher {
+  constructor(private readonly commands: Command[] = []) {}
+
+  dispatch(command: Command): Promise<void> {
+    this.commands.push(command)
+    return Promise.resolve()
+  }
+
+  getCommands(): Command[] {
+    return [...this.commands]
+  }
+
+  reset() {
+    this.commands.length = 0
+  }
+}

--- a/src/adapter/read-model-store-in-memory.ts
+++ b/src/adapter/read-model-store-in-memory.ts
@@ -1,0 +1,102 @@
+import type { QueryOption, ReadModelStore } from '../types/adapter'
+import type { ReadModel } from '../types/core'
+
+export class ReadModelStoreInMemory implements ReadModelStore {
+  storage: Record<string, Record<string, ReadModel>> = {}
+
+  async findMany<T extends ReadModel>(type: T['type'], options: QueryOption<T>): Promise<T[]> {
+    const dataMap = this.storage[type as string]
+    if (!dataMap) return []
+
+    let items: T[] = Object.values(dataMap) as T[]
+
+    // filter
+    if (options.filter) {
+      for (const filterCondition of options.filter) {
+        const { by, operator, value } = filterCondition
+        items = items.filter(item => {
+          const itemValue = item[by]
+          switch (operator) {
+            case 'eq':
+              return itemValue === value
+            case 'ne':
+              return itemValue !== value
+            case 'gt':
+              return itemValue > value
+            case 'gte':
+              return itemValue >= value
+            case 'lt':
+              return itemValue < value
+            case 'lte':
+              return itemValue <= value
+            case 'in':
+              return Array.isArray(value) && value.includes(itemValue)
+            case 'nin':
+              return Array.isArray(value) && !value.includes(itemValue)
+            case 'contains':
+              return (
+                typeof itemValue === 'string' &&
+                typeof value === 'string' &&
+                itemValue.includes(value)
+              )
+            case 'startsWith':
+              return (
+                typeof itemValue === 'string' &&
+                typeof value === 'string' &&
+                itemValue.startsWith(value)
+              )
+            case 'endsWith':
+              return (
+                typeof itemValue === 'string' &&
+                typeof value === 'string' &&
+                itemValue.endsWith(value)
+              )
+            default:
+              return true
+          }
+        })
+      }
+    }
+
+    // sort
+    if (options.sort) {
+      const { by, order } = options.sort
+      items = [...items].sort((a, b) => {
+        const aVal = a[by]
+        const bVal = b[by]
+
+        if (aVal == null || bVal == null) return 0
+        if (aVal < bVal) return order === 'asc' ? -1 : 1
+        if (aVal > bVal) return order === 'asc' ? 1 : -1
+        return 0
+      })
+    }
+
+    // pagination
+    const offset = options.range?.offset ?? 0
+    const limit = options.range?.limit ?? items.length
+    const paged = items.slice(offset, offset + limit)
+
+    return paged
+  }
+
+  async findById<T extends ReadModel>(type: T['type'], id: string): Promise<T | null> {
+    const typeStorage = this.storage[type as string] || {}
+    const readModel = typeStorage[id]
+    if (!readModel) return null
+    return readModel as T
+  }
+
+  async save<T extends ReadModel>(model: T): Promise<void> {
+    const typeStorage = this.storage[model.type] || {}
+    typeStorage[model.id] = model
+    this.storage[model.type] = typeStorage
+  }
+
+  async delete<T extends ReadModel>(model: T): Promise<void> {
+    const typeStorage = this.storage[model.type]
+    if (typeStorage) {
+      delete typeStorage[model.id]
+    }
+  }
+}

--- a/src/event/event-bus.ts
+++ b/src/event/event-bus.ts
@@ -1,0 +1,28 @@
+import type { DomainEvent, ExtendedDomainEvent } from '../types/core'
+import type { AnyEventReactor } from '../types/event'
+import type { EventBus, EventHandlerDeps } from '../types/framework'
+import type { AppError, AsyncResult } from '../types/utils'
+import { err } from '../utils/result'
+import { createEventHandlers } from './event-handler'
+
+export function createEventBus({
+  deps,
+  reactors
+}: {
+  deps: EventHandlerDeps
+  reactors: AnyEventReactor[]
+}): EventBus {
+  const handlers = createEventHandlers(deps, reactors)
+
+  return async (event: ExtendedDomainEvent<DomainEvent>): AsyncResult<void, AppError> => {
+    const handler = handlers[event.id.type]
+    if (!handler) {
+      return err({
+        code: 'EVENT_HANDLER_NOT_FOUND',
+        message: `Handler for event type ${event.type} not found`
+      })
+    }
+
+    return handler(event)
+  }
+}

--- a/src/event/event-handler.ts
+++ b/src/event/event-handler.ts
@@ -1,0 +1,55 @@
+import type { DomainEvent, ExtendedDomainEvent } from '../types/core'
+import type { AnyEventReactor } from '../types/event'
+import type { EventHandler, EventHandlerDeps } from '../types/framework'
+import { err, ok } from '../utils/result'
+import { createDispatchEventFnFactory } from './fn/dispatch-event'
+import { createProjectEventFnFactory } from './fn/project-event'
+
+type EventHandlerFactory<D extends EventHandlerDeps = EventHandlerDeps> = (deps: D) => EventHandler
+
+function createEventHandlerFactory<D extends EventHandlerDeps>(
+  reactor: AnyEventReactor
+): EventHandlerFactory<D> {
+  return (deps: D) => {
+    const dispatch = createDispatchEventFnFactory(reactor.policy)(deps.commandDispatcher)
+    const projection = createProjectEventFnFactory(reactor.projection)(deps.readModelStore)
+
+    return async (event: ExtendedDomainEvent<DomainEvent>) => {
+      try {
+        const [dispatched, projected] = await Promise.all([dispatch(event), projection(event)])
+
+        // Check dispatch result first
+        if (!dispatched.ok) {
+          return dispatched
+        }
+
+        // Check projection result
+        if (!projected.ok) {
+          return projected
+        }
+
+        return ok(undefined)
+      } catch (error) {
+        // Handle unexpected errors that escape the Result type system
+        return err({
+          code: 'EVENT_HANDLER_ERROR',
+          message: 'Unexpected error in event handler',
+          cause: error instanceof Error ? error : new Error(String(error))
+        })
+      }
+    }
+  }
+}
+
+export function createEventHandlers(
+  deps: EventHandlerDeps,
+  eventReactors: AnyEventReactor[]
+): Record<string, EventHandler> {
+  const handlers: Record<string, EventHandler> = {}
+
+  for (const reactor of eventReactors) {
+    handlers[reactor.type] = createEventHandlerFactory(reactor)(deps)
+  }
+
+  return handlers
+}

--- a/src/event/event-reactor-builder.ts
+++ b/src/event/event-reactor-builder.ts
@@ -1,0 +1,255 @@
+import type { Draft } from 'immer'
+import type { Command, DomainEvent, ReadModel } from '../types/core'
+import type {
+  EventReactor,
+  Policy,
+  PolicyFn,
+  PolicyMap,
+  PolicyParams,
+  Projection,
+  ProjectionFn,
+  ProjectionMap,
+  ProjectionParams
+} from '../types/event'
+
+/**
+ * Internal type representing the accumulated values in the builder
+ */
+type BuilderValue<E extends DomainEvent, C extends Command, RM extends ReadModel> = {
+  type: E['id']['type']
+  policy: Policy<E, C> | Policy<E, C, PolicyMap<E, C>>
+  policyMap?: PolicyMap<E, C>
+  projection: Projection<E, RM, ProjectionMap<E, RM>>
+  projectionMap?: ProjectionMap<E, RM>
+}
+
+/**
+ * Builder state types for enforcing correct method call order
+ */
+export type BuilderState = 'initial' | 'hasType' | 'hasPolicy' | 'hasProjection' | 'complete'
+
+/**
+ * Public interface for event reactor builder
+ * Provides type-safe fluent API for building event reactors
+ */
+export interface IEventReactorBuilder<
+  ST extends BuilderState,
+  C extends Command,
+  E extends DomainEvent,
+  RM extends ReadModel
+> {
+  readonly _state: ST
+
+  type<RT extends string>(
+    this: IEventReactorBuilder<'initial', E, C, RM>,
+    value: RT
+  ): IEventReactorBuilder<'hasType', E, C, RM>
+
+  policy(
+    this: IEventReactorBuilder<'hasType', E, C, RM>,
+    value: Policy<E, C>
+  ): IEventReactorBuilder<'hasPolicy', E, C, RM>
+
+  policyWithMap(
+    this: IEventReactorBuilder<'hasType', E, C, RM>,
+    value: Policy<E, C>,
+    transitionMap: PolicyMap<E, C>
+  ): IEventReactorBuilder<'hasPolicy', E, C, RM>
+
+  projection(
+    this: IEventReactorBuilder<'hasPolicy', E, C, RM>,
+    value: Projection<E, RM, ProjectionMap<E, RM>>
+  ): IEventReactorBuilder<'complete', E, C, RM>
+
+  projectionWithMap(
+    this: IEventReactorBuilder<'hasPolicy', E, C, RM>,
+    value: Projection<E, RM, ProjectionMap<E, RM>>,
+    transitionMap: ProjectionMap<E, RM>
+  ): IEventReactorBuilder<'complete', E, C, RM>
+
+  build(this: IEventReactorBuilder<'complete', E, C, RM>): EventReactor<C, E, RM>
+}
+
+/**
+ * Validates that all required builder values are present
+ */
+function isRequiredBuilderValue<E extends DomainEvent, C extends Command, RM extends ReadModel>(
+  value: Partial<BuilderValue<E, C, RM>>
+): value is BuilderValue<E, C, RM> {
+  return (
+    typeof value.type === 'string' &&
+    value.policy !== undefined &&
+    typeof value.policy === 'object' &&
+    value.projection !== undefined &&
+    typeof value.projection === 'object'
+  )
+}
+
+/**
+ * Helper to safely convert any policy to PolicyFn
+ */
+function createPolicyFn<E extends DomainEvent, C extends Command>(
+  policy: Policy<E, C> | Policy<E, C, PolicyMap<E, C>>
+): PolicyFn<E, C> {
+  // Type-safe policy conversion without type assertion
+  return fromPolicy(policy as Policy<E, C>)
+}
+
+/**
+ * Converts Policy object to PolicyFn
+ */
+function fromPolicy<E extends DomainEvent, C extends Command>(
+  policies: Policy<E, C>
+): PolicyFn<E, C> {
+  return (params: PolicyParams<E>): C | null => {
+    const eventType = params.event.type
+
+    // Type-safe key checking without type assertion
+    if (!(eventType in policies)) {
+      return null
+    }
+
+    const policy = policies[eventType as keyof typeof policies]
+    if (!policy || typeof policy !== 'function') {
+      return null
+    }
+
+    // Type-safe parameter casting
+    type EventOfType = Extract<E, { type: typeof eventType }>
+    return policy(params as PolicyParams<EventOfType>)
+  }
+}
+
+/**
+ * Helper to safely convert any projection to ProjectionFn
+ */
+function createProjectionFn<E extends DomainEvent, RM extends ReadModel>(
+  projection: Projection<E, RM, ProjectionMap<E, RM>>
+): ProjectionFn<E, RM> {
+  // Type-safe policy conversion without type assertion
+  return fromProjection(projection)
+}
+
+/**
+ * Converts Projection object to ProjectionFn
+ */
+function fromProjection<E extends DomainEvent, RM extends ReadModel>(
+  projections: Projection<E, RM, ProjectionMap<E, RM>>
+): ProjectionFn<E, RM> {
+  return (params: ProjectionParams<E, RM>): RM => {
+    const eventType = params.event.type
+
+    // Type-safe key checking without type assertion
+    if (!(eventType in projections)) {
+      return params.readModel
+    }
+
+    const projection = projections[eventType as keyof typeof projections]
+    if (!projection || typeof projection !== 'object') {
+      return params.readModel
+    }
+
+    // Get the readModel type from params
+    const readModelType = params.readModel.type
+    const projectionFn = projection[readModelType as keyof typeof projection]
+
+    if (!projectionFn || typeof projectionFn !== 'function') {
+      return params.readModel
+    }
+
+    // Type-safe parameter casting
+    const result = projectionFn(
+      params as ProjectionParams<
+        Extract<E, { type: typeof eventType }>,
+        Draft<Extract<RM, { type: keyof typeof projection }>>
+      >
+    )
+
+    return result ?? params.readModel
+  }
+}
+
+export class EventReactorBuilder<
+  ST extends BuilderState,
+  E extends DomainEvent,
+  C extends Command,
+  RM extends ReadModel
+> {
+  // @ts-expect-error: phantom type to enforce state transitions
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: phantom type to enforce state transitions
+  private readonly _state!: ST
+
+  constructor(private readonly value: Readonly<Partial<BuilderValue<E, C, RM>>>) {}
+
+  type(
+    this: EventReactorBuilder<'initial', E, C, RM>,
+    type: E['id']['type']
+  ): EventReactorBuilder<'hasType', E, C, RM> {
+    return this.withValue<'hasType', { type: E['id']['type'] }>({ type })
+  }
+
+  policy(
+    this: EventReactorBuilder<'hasType', E, C, RM>,
+    policy: Policy<E, C>
+  ): EventReactorBuilder<'hasPolicy', E, C, RM> {
+    return this.withValue<'hasPolicy', { policy: Policy<E, C> }>({ policy })
+  }
+
+  policyWithMap<PM extends PolicyMap<E, C>>(
+    this: EventReactorBuilder<'hasType', E, C, RM>,
+    policy: Policy<E, C, PM>,
+    transitionMap: PM
+  ): EventReactorBuilder<'hasPolicy', E, C, RM> {
+    return this.withValue<'hasPolicy', { policy: Policy<E, C, PM>; policyMap: PM }>({
+      policy,
+      policyMap: transitionMap
+    })
+  }
+
+  projection(
+    this: EventReactorBuilder<'hasPolicy', E, C, RM>,
+    projection: Projection<E, RM, ProjectionMap<E, RM>>
+  ): EventReactorBuilder<'complete', E, C, RM> {
+    return this.withValue<'complete', { projection: Projection<E, RM, ProjectionMap<E, RM>> }>({
+      projection
+    })
+  }
+
+  projectionWithMap<PJM extends ProjectionMap<E, RM>>(
+    this: EventReactorBuilder<'hasPolicy', E, C, RM>,
+    projection: Projection<E, RM, PJM>,
+    transitionMap: PJM
+  ): EventReactorBuilder<'complete', E, C, RM> {
+    return this.withValue<'complete', { projection: Projection<E, RM, PJM>; projectionMap: PJM }>({
+      projection,
+      projectionMap: transitionMap
+    })
+  }
+
+  private withValue<NS extends BuilderState, T extends Partial<BuilderValue<E, C, RM>>>(
+    updates: T
+  ): EventReactorBuilder<NS, E, C, RM> {
+    const newValue = { ...this.value, ...updates }
+    return new EventReactorBuilder<NS, E, C, RM>(newValue)
+  }
+
+  build(this: EventReactorBuilder<'complete', E, C, RM>): EventReactor<C, E, RM> {
+    if (!isRequiredBuilderValue(this.value)) {
+      throw new Error('EventReactor is not ready to build. Missing required properties.')
+    }
+
+    return {
+      type: this.value.type,
+      policy: createPolicyFn(this.value.policy),
+      projection: createProjectionFn(this.value.projection)
+    }
+  }
+}
+
+export function createEventReactor<
+  E extends DomainEvent,
+  C extends Command,
+  RM extends ReadModel
+>() {
+  return new EventReactorBuilder<'initial', E, C, RM>({})
+}

--- a/src/event/fn/dispatch-event.ts
+++ b/src/event/fn/dispatch-event.ts
@@ -1,0 +1,34 @@
+import type { CommandDispatcher } from '../../types/adapter'
+import type { Command, DomainEvent, ExtendedDomainEvent } from '../../types/core'
+import type { PolicyFn } from '../../types/event'
+import type { AppError, AsyncResult } from '../../types/utils'
+import { err, ok, toAsyncResult } from '../../utils/result'
+
+type DispatchEventFn<E extends DomainEvent> = (
+  event: ExtendedDomainEvent<E>
+) => AsyncResult<void, AppError>
+
+export function createDispatchEventFnFactory<E extends DomainEvent, C extends Command>(
+  policy: PolicyFn<E, C>
+): (deps: CommandDispatcher) => DispatchEventFn<E> {
+  return (deps: CommandDispatcher) => {
+    return async (event: ExtendedDomainEvent<E>): AsyncResult<void, AppError> => {
+      const command = policy({
+        ctx: { timestamp: event.timestamp },
+        event
+      })
+      if (!command) return ok(undefined)
+
+      const dispatched = await toAsyncResult(() => deps.dispatch(command))
+      if (!dispatched.ok) {
+        return err({
+          code: 'COMMAND_DISPATCH_FAILED',
+          message: 'Command dispatch failed',
+          cause: dispatched.error
+        })
+      }
+
+      return ok(undefined)
+    }
+  }
+}

--- a/src/event/fn/project-event.ts
+++ b/src/event/fn/project-event.ts
@@ -1,0 +1,93 @@
+import { produce } from 'immer'
+import type { ReadModelStore } from '../../types/adapter'
+import type { DomainEvent, ExtendedDomainEvent, ReadModel } from '../../types/core'
+import type { ProjectionCtx, ProjectionFn } from '../../types/event'
+import type { AppError, AsyncResult } from '../../types/utils'
+import { err, ok, toAsyncResult } from '../../utils/result'
+
+export type ProjectEventFn<E extends DomainEvent> = (
+  event: ExtendedDomainEvent<E>
+) => AsyncResult<void, AppError>
+
+export function createProjectEventFnFactory<E extends DomainEvent>(
+  projection: ProjectionFn<E, ReadModel>
+): (store: ReadModelStore) => ProjectEventFn<E> {
+  return (store: ReadModelStore) => {
+    return async (event: ExtendedDomainEvent<E>): AsyncResult<void, AppError> => {
+      const eventType = event.type
+
+      // Type-safe event type validation
+      if (typeof eventType !== 'string') {
+        return err({
+          code: 'INVALID_EVENT_TYPE',
+          message: `Event type must be string, got: ${typeof eventType}`
+        })
+      }
+      // 型安全のため eventType を keyof ProjectionFn<E, ReadModel> として扱う
+      if (!(eventType in projection)) {
+        return err({
+          code: 'EVENT_TYPE_NOT_FOUND',
+          message: `Event type ${eventType} not found`
+        })
+      }
+      const definitions = projection[eventType as keyof typeof projection]
+      if (!definitions) {
+        return err({
+          code: 'EVENT_TYPE_NOT_FOUND',
+          message: `Event type ${eventType} not found`
+        })
+      }
+
+      for (const [type, definition] of Object.entries(definitions)) {
+        if (!definition || typeof definition !== 'function') {
+          continue
+        }
+
+        const ctx: ProjectionCtx = {
+          timestamp: event.timestamp
+        }
+
+        const existingReadModel = await toAsyncResult(() => store.findById(type, event.id.value))
+        const readModelToUpdate =
+          existingReadModel.ok && existingReadModel.value ? existingReadModel.value : {}
+
+        try {
+          const updatedReadModel = produce(readModelToUpdate, draft => {
+            const result = definition({
+              ctx,
+              event: event,
+              readModel: draft
+            })
+            if (result) {
+              return result
+            }
+          })
+
+          // Save the result if it exists and has content
+          if (
+            updatedReadModel &&
+            typeof updatedReadModel === 'object' &&
+            Object.keys(updatedReadModel).length > 0
+          ) {
+            const saved = await toAsyncResult(() => store.save(updatedReadModel as ReadModel))
+            if (!saved.ok) {
+              return err({
+                code: 'SAVE_VIEW_FAILED',
+                message: `SavereadModel failed: ${type} event: ${event.type} v${event.version}`,
+                cause: saved.error
+              })
+            }
+          }
+        } catch (error) {
+          return err({
+            code: 'PROJECTION_EXECUTION_FAILED',
+            message: `Projection execution failed: ${type} event: ${event.type} v${event.version}`,
+            cause: error
+          })
+        }
+      }
+
+      return ok(undefined)
+    }
+  }
+}

--- a/tests/event/event-bus.test.ts
+++ b/tests/event/event-bus.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'bun:test'
+import { CommandDispatcherMock } from '../../src/adapter/command-dispatcher-mock'
+import { ReadModelStoreInMemory } from '../../src/adapter/read-model-store-in-memory'
+import { zeroId } from '../../src/command/helpers/aggregate-id'
+import { createEventBus } from '../../src/event/event-bus'
+import type { AggregateId, ExtendedDomainEvent, ReadModel } from '../../src/types/core'
+import type { EventReactor } from '../../src/types/event'
+
+// Test types
+type TestCommand = { type: 'notify'; id: AggregateId<'test'>; payload: { message: string } }
+
+type TestEvent = ExtendedDomainEvent<{
+  type: 'created'
+  id: AggregateId<'test'>
+  payload: { name: string }
+}>
+
+type TestReadModel = ReadModel & {
+  type: 'test'
+  id: string
+  name: string
+}
+
+const createTestReactor = (): EventReactor<TestCommand, TestEvent, TestReadModel> => ({
+  type: 'test',
+  policy: () => null,
+  projection: {
+    created: {
+      test: () => ({ type: 'test', id: '123', name: 'test' })
+    }
+  }
+})
+
+describe('[event] event bus', () => {
+  describe('createEventBus', () => {
+    test('creates event bus with dependencies and reactors', () => {
+      // Arrange
+      const deps = {
+        commandDispatcher: new CommandDispatcherMock(),
+        readModelStore: new ReadModelStoreInMemory()
+      }
+      const reactors = [createTestReactor()]
+
+      // Act
+      const eventBus = createEventBus({ deps, reactors })
+
+      // Assert
+      expect(eventBus).toBeDefined()
+      expect(typeof eventBus).toBe('function')
+    })
+
+    test('creates event bus with empty reactors array', () => {
+      // Arrange
+      const deps = {
+        commandDispatcher: new CommandDispatcherMock(),
+        readModelStore: new ReadModelStoreInMemory()
+      }
+      const reactors: EventReactor<any, any, any>[] = []
+
+      // Act
+      const eventBus = createEventBus({ deps, reactors })
+
+      // Assert
+      expect(eventBus).toBeDefined()
+      expect(typeof eventBus).toBe('function')
+    })
+  })
+
+  describe('event processing', () => {
+    test('processes event successfully when handler exists', async () => {
+      // Arrange
+      const deps = {
+        commandDispatcher: new CommandDispatcherMock(),
+        readModelStore: new ReadModelStoreInMemory()
+      }
+      const reactor = createTestReactor()
+      const eventBus = createEventBus({ deps, reactors: [reactor] })
+      const event: TestEvent = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const res = await eventBus(event)
+
+      // Assert
+      expect(res.ok).toBe(true)
+    })
+
+    test('returns error when handler not found', async () => {
+      // Arrange
+      const deps = {
+        commandDispatcher: new CommandDispatcherMock(),
+        readModelStore: new ReadModelStoreInMemory()
+      }
+      const eventBus = createEventBus({ deps, reactors: [] })
+      const event: TestEvent = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const res = await eventBus(event)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('EVENT_HANDLER_NOT_FOUND')
+        expect(res.error.message).toBe('Handler for event type created not found')
+      }
+    })
+
+    test('returns error when handler not found for specific aggregate type', async () => {
+      // Arrange
+      const deps = {
+        commandDispatcher: new CommandDispatcherMock(),
+        readModelStore: new ReadModelStoreInMemory()
+      }
+      const reactor: EventReactor<TestCommand, TestEvent, TestReadModel> = {
+        type: 'test',
+        policy: () => null,
+        projection: {
+          created: {
+            test: () => ({ type: 'test', id: '123', name: 'test' })
+          }
+        }
+      }
+      const eventBus = createEventBus({ deps, reactors: [reactor] })
+      const event = {
+        type: 'created',
+        id: { type: 'hoge', value: '123' },
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const res = await eventBus(event)
+
+      // Assert
+      expect(res.ok).toBe(false)
+      if (!res.ok) {
+        expect(res.error.code).toBe('EVENT_HANDLER_NOT_FOUND')
+      }
+    })
+  })
+})

--- a/tests/event/event-handler.test.ts
+++ b/tests/event/event-handler.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from 'bun:test'
+import { zeroId } from '../../src'
+import { createEventHandlers } from '../../src/event/event-handler'
+import type { CommandDispatcher, QueryOption, ReadModelStore } from '../../src/types/adapter'
+import type { AggregateId, ReadModel } from '../../src/types/core'
+import type { EventReactor } from '../../src/types/event'
+
+// Test types
+type TestCommand = { type: 'notify'; id: AggregateId<'test'>; payload: { message: string } }
+type TestEvent = { type: 'created'; id: AggregateId<'test'>; payload: { name: string } }
+type TestReadModel = ReadModel & { type: 'test'; id: string; name: string }
+
+// Mock classes for testing error scenarios
+class MockCommandDispatcherError implements CommandDispatcher {
+  async dispatch(): Promise<void> {
+    throw new Error('Mock dispatch error')
+  }
+}
+
+class MockReadModelStoreError implements ReadModelStore {
+  async findMany<T extends ReadModel>(_type: T['type'], _optionss: unknown): Promise<T[]> {
+    throw new Error('Mock database error')
+  }
+
+  async findById<T extends ReadModel>(_type: T['type'], _idd: string): Promise<T | null> {
+    throw new Error('Mock database error')
+  }
+
+  async save(): Promise<void> {
+    throw new Error('Mock save error')
+  }
+
+  async delete(): Promise<void> {
+    throw new Error('Mock delete error')
+  }
+}
+
+class MockReadModelStoreThrows implements ReadModelStore {
+  async findMany<T extends ReadModel>(_type: T['type'], _optionss: QueryOption<T>): Promise<T[]> {
+    throw new Error('Method not implemented.')
+  }
+  async findById<T extends ReadModel>(_type: T['type'], _idd: string): Promise<T | null> {
+    throw new Error('Method not implemented.')
+  }
+
+  async save(): Promise<void> {
+    throw new Error('Save operation failed')
+  }
+
+  async delete(): Promise<void> {
+    throw new Error('Delete operation failed')
+  }
+}
+
+describe('[event] event handler', () => {
+  describe('error handling in dispatch operations', () => {
+    test('handles dispatch errors from policy execution', async () => {
+      // Arrange
+      const reactor: EventReactor<TestCommand, TestEvent, TestReadModel> = {
+        type: 'test',
+        policy: () => ({
+          type: 'notify',
+          id: zeroId('test'),
+          payload: { message: 'test' }
+        }),
+        projection: {
+          created: {
+            test: () => ({
+              type: 'test',
+              id: '123',
+              name: 'test'
+            })
+          }
+        }
+      }
+
+      const deps = {
+        commandDispatcher: new MockCommandDispatcherError(),
+        ReadModelStore: new MockReadModelStoreError()
+      }
+
+      const handlers = createEventHandlers(deps, [reactor])
+      const event = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const result = await handlers['test']!(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('COMMAND_DISPATCH_FAILED')
+      }
+    })
+  })
+
+  describe('error handling in projection operations', () => {
+    test('handles projection errors when database operations fail', async () => {
+      // Arrange
+      const reactor: EventReactor<TestCommand, TestEvent, TestReadModel> = {
+        type: 'test',
+        policy: () => null, // No command dispatch
+        projection: {
+          created: {
+            test: () => ({
+              type: 'test',
+              id: '123',
+              name: 'test'
+            })
+          }
+        }
+      }
+
+      const deps = {
+        commandDispatcher: new MockCommandDispatcherError(),
+        ReadModelStore: new MockReadModelStoreError()
+      }
+
+      const handlers = createEventHandlers(deps, [reactor])
+      const event = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const result = await handlers['test']!(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('SAVE_VIEW_FAILED')
+      }
+    })
+  })
+
+  describe('unexpected error handling', () => {
+    test('handles unexpected errors that escape the Result type system', async () => {
+      // Arrange
+      const reactor: EventReactor<TestCommand, TestEvent, TestReadModel> = {
+        type: 'test',
+        policy: () => null,
+        projection: {
+          created: {
+            test: ({ event }) => ({
+              type: 'test',
+              id: event.id.value,
+              name: 'test'
+            })
+          }
+        }
+      }
+
+      const deps = {
+        commandDispatcher: new MockCommandDispatcherError(),
+        ReadModelStore: new MockReadModelStoreThrows()
+      }
+
+      const handlers = createEventHandlers(deps, [reactor])
+      const event = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const result = await handlers['test']!(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('SAVE_VIEW_FAILED')
+      }
+    })
+
+    test('handles non-Error exceptions gracefully', async () => {
+      // Arrange
+      class ThrowsStringDatabase implements ReadModelStore {
+        findMany<T extends ReadModel>(_type: T['type'], _optionss: QueryOption<T>): Promise<T[]> {
+          throw new Error('Method not implemented.')
+        }
+        findById<T extends ReadModel>(_type: T['type'], _idd: string): Promise<T | null> {
+          throw new Error('Method not implemented.')
+        }
+        async save(): Promise<void> {
+          throw 'String error'
+        }
+
+        async delete(): Promise<void> {
+          throw 'String error'
+        }
+      }
+
+      const reactor: EventReactor<TestCommand, TestEvent, TestReadModel> = {
+        type: 'test',
+        policy: () => null,
+        projection: {
+          created: {
+            test: ({ event }) => ({
+              type: 'test',
+              id: event.id.value,
+              name: 'test'
+            })
+          }
+        }
+      }
+
+      const deps = {
+        commandDispatcher: new MockCommandDispatcherError(),
+        ReadModelStore: new ThrowsStringDatabase()
+      }
+
+      const handlers = createEventHandlers(deps, [reactor])
+      const event = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const result = await handlers['test']!(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('SAVE_VIEW_FAILED')
+      }
+    })
+  })
+})

--- a/tests/event/event-reactor-builder.test.ts
+++ b/tests/event/event-reactor-builder.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from 'bun:test'
+import { zeroId } from '../../src/command/helpers/aggregate-id'
+import { createEventReactor } from '../../src/event/event-reactor-builder'
+import type { AggregateId, ReadModel } from '../../src/types/core'
+import type { Policy, PolicyMap, Projection, ProjectionMap } from '../../src/types/event'
+
+type TestCommand =
+  | { type: 'notify'; id: AggregateId<'test'>; payload: { message: string } }
+  | { type: 'alert'; id: AggregateId<'test'>; payload: { level: string } }
+
+type TestEvent =
+  | { type: 'created'; id: AggregateId<'test'>; payload: { name: string } }
+  | { type: 'updated'; id: AggregateId<'test'>; payload: { name: string } }
+  | { type: 'deleted'; id: AggregateId<'test'> }
+
+type TestReadModel = ReadModel & {
+  type: 'test'
+  id: string
+  name: string
+  status: 'active' | 'inactive'
+  createdAt: Date
+  updatedAt: Date
+}
+
+const testPolicy: Policy<TestEvent, TestCommand> = {
+  created: ({ event }) => ({
+    type: 'notify',
+    id: event.id,
+    payload: { message: `Item ${event.payload.name} was created` }
+  }),
+  updated: ({ event }) => ({
+    type: 'alert',
+    id: event.id,
+    payload: { level: 'info' }
+  }),
+  deleted: () => null
+}
+
+const testProjection = {
+  created: {
+    test: ({ ctx, event }: any) => {
+      const typedEvent = event as Extract<TestEvent, { type: 'created' }>
+      return {
+        type: 'test' as const,
+        id: typedEvent.id.value,
+        name: typedEvent.payload.name,
+        status: 'active' as const,
+        createdAt: ctx.timestamp,
+        updatedAt: ctx.timestamp
+      }
+    }
+  },
+  updated: {
+    test: ({ ctx, readModel, event }: any) => {
+      const typedEvent = event as Extract<TestEvent, { type: 'updated' }>
+      readModel.name = typedEvent.payload.name
+      readModel.updatedAt = ctx.timestamp
+      return readModel
+    }
+  },
+  deleted: {
+    test: () => {
+      // For delete operations, we don't return areadModel
+      return undefined
+    }
+  }
+} satisfies Projection<TestEvent, TestReadModel, ProjectionMap<TestEvent, TestReadModel>>
+
+describe('[event] event reactor builder', () => {
+  describe('createEventReactor', () => {
+    test('creates event reactor builder instance', () => {
+      // Arrange & Act
+      const builder = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+
+      // Assert
+      expect(builder).toBeDefined()
+      expect(typeof builder.type).toBe('function')
+    })
+  })
+
+  describe('event reactor building and functionality', () => {
+    test('builds functioning event reactor with basic configuration', () => {
+      // Arrange & Act
+      const reactor = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+        .type('test')
+        .policy(testPolicy)
+        .projection(testProjection)
+        .build()
+
+      // Assert
+      expect(reactor).toBeDefined()
+      expect(reactor.type).toBe('test')
+      expect(typeof reactor.policy).toBe('function')
+      expect(typeof reactor.projection).toBe('function')
+    })
+
+    test('builds functioning event reactor with policy and projection maps', () => {
+      // Arrange
+      const policyMap: PolicyMap<TestEvent, TestCommand> = {
+        created: ['notify'],
+        updated: ['alert'],
+        deleted: []
+      }
+
+      const projectionMap: ProjectionMap<TestEvent, TestReadModel> = {
+        created: [{ readModel: 'test' }],
+        updated: [{ readModel: 'test' }],
+        deleted: [{ readModel: 'test' }]
+      }
+
+      // Act
+      const reactor = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+        .type('test')
+        .policyWithMap(testPolicy, policyMap)
+        .projectionWithMap(testProjection, projectionMap)
+        .build()
+
+      // Assert
+      expect(reactor.type).toBe('test')
+      expect(typeof reactor.policy).toBe('function')
+      expect(typeof reactor.projection).toBe('function')
+    })
+
+    test('builds functioning event reactor with policy map and projection', () => {
+      // Arrange
+      const policyMap: PolicyMap<TestEvent, TestCommand> = {
+        created: ['notify'],
+        updated: ['alert'],
+        deleted: []
+      }
+
+      // Act
+      const reactor = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+        .type('test')
+        .policyWithMap(testPolicy, policyMap)
+        .projection(testProjection)
+        .build()
+
+      // Assert
+      expect(reactor.type).toBe('test')
+      expect(typeof reactor.policy).toBe('function')
+      expect(typeof reactor.projection).toBe('function')
+    })
+
+    test('builds functioning event reactor with policy and projection map', () => {
+      // Arrange
+      const projectionMap: ProjectionMap<TestEvent, TestReadModel> = {
+        created: [{ readModel: 'test' }],
+        updated: [{ readModel: 'test' }],
+        deleted: [{ readModel: 'test' }]
+      }
+
+      // Act
+      const reactor = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+        .type('test')
+        .policy(testPolicy)
+        .projectionWithMap(testProjection, projectionMap)
+        .build()
+
+      // Assert
+      expect(reactor.type).toBe('test')
+      expect(typeof reactor.policy).toBe('function')
+      expect(typeof reactor.projection).toBe('function')
+    })
+
+    test('created reactor processes policy correctly', () => {
+      // Arrange
+      const reactor = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+        .type('test')
+        .policy(testPolicy)
+        .projection(testProjection)
+        .build()
+
+      const id = zeroId('test')
+      const event: TestEvent = {
+        type: 'created',
+        id,
+        payload: { name: 'Test Item' }
+      }
+
+      const policyParams = {
+        ctx: { timestamp: new Date() },
+        event: event
+      }
+
+      // Act
+      const command = reactor.policy(policyParams)
+
+      // Assert
+      expect(command).toBeDefined()
+      expect(command?.type).toBe('notify')
+      if (command?.type === 'notify') {
+        expect(command.payload.message).toBe('Item Test Item was created')
+      }
+    })
+
+    test('created reactor handles events with no policy response', () => {
+      // Arrange
+      const reactor = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+        .type('test')
+        .policy(testPolicy)
+        .projection(testProjection)
+        .build()
+
+      const id = zeroId('test')
+      const event: TestEvent = {
+        type: 'deleted',
+        id
+      }
+
+      const policyParams = {
+        ctx: { timestamp: new Date() },
+        event: event
+      }
+
+      // Act
+      const command = reactor.policy(policyParams)
+
+      // Assert
+      expect(command).toBeNull()
+    })
+
+    test('created reactor has correct projection functionality', () => {
+      // Arrange & Act
+      const reactor = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+        .type('test')
+        .policy(testPolicy)
+        .projection(testProjection)
+        .build()
+
+      const id = zeroId('test')
+      const event: TestEvent = {
+        type: 'created',
+        id,
+        payload: { name: 'Test Item' }
+      }
+
+      const readModel: TestReadModel = {
+        type: 'test',
+        id: id.value,
+        name: '',
+        status: 'inactive',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+
+      const projectionParams = {
+        ctx: { timestamp: new Date() },
+        event: event,
+        readModel: readModel
+      }
+
+      // Assert
+      expect(reactor.projection).toBeDefined()
+      expect(typeof reactor.projection).toBe('function')
+
+      // Test that projection function works correctly
+      const result = reactor.projection(projectionParams)
+      expect(result).toBeDefined()
+      expect(result.name).toBe('Test Item')
+      expect(result.status).toBe('active')
+    })
+
+    test('throws error when building incomplete reactor', () => {
+      // Arrange
+      const incompleteBuilder = createEventReactor<TestEvent, TestCommand, TestReadModel>()
+        .type('test')
+        .policy(testPolicy)
+      // Missing projection
+
+      // Act & Assert
+      expect(() => {
+        // @ts-expect-error - This should fail at compile time, but we test runtime behavior
+        incompleteBuilder.build()
+      }).toThrow('EventReactor is not ready to build. Missing required properties.')
+    })
+  })
+})

--- a/tests/event/fn/dispatch-event.test.ts
+++ b/tests/event/fn/dispatch-event.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test'
+import { zeroId } from '../../../src/command/helpers/aggregate-id'
+import { createDispatchEventFnFactory } from '../../../src/event/fn/dispatch-event'
+import type { CommandDispatcher } from '../../../src/types/adapter'
+import type { AggregateId, ExtendedDomainEvent } from '../../../src/types/core'
+
+type TestEvent = { type: 'created'; id: AggregateId<'test'>; payload: { name: string } }
+
+// Mock command dispatcher that fails
+class MockCommandDispatcherError implements CommandDispatcher {
+  async dispatch() {
+    throw new Error('Mock dispatch failed')
+  }
+}
+
+// Mock command dispatcher that succeeds
+class MockCommandDispatcherSuccess implements CommandDispatcher {
+  async dispatch() {
+    throw new Error('Mock dispatch failed')
+  }
+}
+
+describe('[event] dispatch event function', () => {
+  describe('createDispatchEventFnFactory', () => {
+    test('returns ok when policy returns no command', async () => {
+      // Arrange
+      const policy = () => null
+      const dispatcher = new MockCommandDispatcherSuccess()
+      const dispatchFn = createDispatchEventFnFactory(policy)(dispatcher)
+      const event: ExtendedDomainEvent<TestEvent> = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const result = await dispatchFn(event)
+
+      // Assert
+      expect(result.ok).toBe(true)
+    })
+
+    test('handles command dispatch failure', async () => {
+      // Arrange
+      const policy = () => ({
+        type: 'notify' as const,
+        id: zeroId('test'),
+        payload: { message: 'test' }
+      })
+      const dispatcher = new MockCommandDispatcherError()
+      const dispatchFn = createDispatchEventFnFactory(policy)(dispatcher)
+      const event: ExtendedDomainEvent<TestEvent> = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const result = await dispatchFn(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('COMMAND_DISPATCH_FAILED')
+        expect(result.error.message).toBe('Command dispatch failed')
+      }
+    })
+
+    test('returns ok when command dispatch succeeds', async () => {
+      // Arrange
+      class MockCommandDispatcherOk implements CommandDispatcher {
+        async dispatch() {
+          return Promise.resolve()
+        }
+      }
+
+      const policy = () => ({
+        type: 'notify' as const,
+        id: zeroId('test'),
+        payload: { message: 'test' }
+      })
+      const dispatcher = new MockCommandDispatcherOk()
+      const dispatchFn = createDispatchEventFnFactory(policy)(dispatcher)
+      const event: ExtendedDomainEvent<TestEvent> = {
+        type: 'created',
+        id: zeroId('test'),
+        payload: { name: 'test' },
+        version: 1,
+        timestamp: new Date()
+      }
+
+      // Act
+      const result = await dispatchFn(event)
+
+      // Assert
+      expect(result.ok).toBe(true)
+    })
+  })
+})

--- a/tests/event/fn/project-event.test.ts
+++ b/tests/event/fn/project-event.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, test } from 'bun:test'
+import { createProjectEventFnFactory } from '../../../src/event/fn/project-event'
+import type { QueryOption, ReadModelStore } from '../../../src/types/adapter'
+import type { AggregateId, ExtendedDomainEvent, ReadModel } from '../../../src/types/core'
+import type { Projection, ProjectionMap } from '../../../src/types/event'
+
+// Test types
+type TestEvent =
+  | { type: 'created'; id: AggregateId<'test'>; payload: { name: string } }
+  | { type: 'updated'; id: AggregateId<'test'>; payload: { name: string } }
+  | { type: 'deleted'; id: AggregateId<'test'> }
+
+type TestReadModel = ReadModel & {
+  type: 'test'
+  id: string
+  name: string
+}
+
+const testId = (id: string): AggregateId<'test'> => ({ type: 'test', value: id })
+
+const createTestEvent = (
+  type: TestEvent['type'],
+  id: string,
+  payload?: any
+): ExtendedDomainEvent<TestEvent> =>
+  ({
+    type,
+    id: testId(id),
+    payload,
+    aggregateId: testId(id),
+    version: 1,
+    timestamp: new Date()
+  }) as ExtendedDomainEvent<TestEvent>
+
+// Mock database classes for testing error scenarios
+class MockReadModelStore implements ReadModelStore {
+  async findMany<T extends ReadModel>(_type: T['type'], _optionss: QueryOption<T>): Promise<T[]> {
+    return []
+  }
+
+  async findById<T extends ReadModel>(_type: T['type'], _idd: string): Promise<T | null> {
+    return {
+      type: 'test',
+      id: '123',
+      name: 'existing'
+    } as unknown as T
+  }
+
+  async save<T extends ReadModel>(_model: T): Promise<void> {
+    // Success - do nothing
+  }
+
+  async delete<T extends ReadModel>(_model: T): Promise<void> {
+    // Success - do nothing
+  }
+}
+
+class MockReadModelStoreWithErrors implements ReadModelStore {
+  constructor(
+    private shouldFailOnGet = false,
+    private shouldFailOnSave = false,
+    private shouldFailOnDelete = false
+  ) {}
+
+  async findMany<T extends ReadModel>(_type: T['type'], _optionss: QueryOption<T>): Promise<T[]> {
+    return []
+  }
+
+  async findById<T extends ReadModel>(_type: T['type'], _idd: string): Promise<T | null> {
+    if (this.shouldFailOnGet) {
+      throw new Error('Get by ID failed')
+    }
+    return {
+      type: 'test',
+      id: '123',
+      name: 'existing'
+    } as unknown as T
+  }
+
+  async save<T extends ReadModel>(_model: T): Promise<void> {
+    if (this.shouldFailOnSave) {
+      throw new Error('Save operation failed')
+    }
+  }
+
+  async delete<T extends ReadModel>(_model: T): Promise<void> {
+    if (this.shouldFailOnDelete) {
+      throw new Error('Delete operation failed')
+    }
+  }
+}
+
+describe('[event] project event function', () => {
+  describe('createProjectEventFnFactory', () => {
+    test('handles invalid event type (non-string)', async () => {
+      // Arrange
+      const projection = {
+        created: {
+          test: (_params: any) => ({ type: 'mutate' })
+        }
+      }
+
+      const db = new MockReadModelStoreWithErrors()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const invalidEvent = {
+        ...createTestEvent('created', '123'),
+        type: 123 // Invalid type
+      } as any
+
+      // Act
+      const result = await projectFn(invalidEvent)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_EVENT_TYPE')
+        expect(result.error.message).toContain('Event type must be string')
+      }
+    })
+
+    test('handles event type not found in projection', async () => {
+      // Arrange
+      const projection = {
+        created: {
+          test: (_params: any) => ({ type: 'mutate' })
+        }
+      }
+
+      const db = new MockReadModelStoreWithErrors()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('updated', '123', { name: 'test' })
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('EVENT_TYPE_NOT_FOUND')
+        expect(result.error.message).toBe('Event type updated not found')
+      }
+    })
+
+    test('skips invalid projection definitions', async () => {
+      // Arrange
+      const projection = {
+        created: {
+          test: null, // Invalid definition
+          validReadModel: (_params: unknown) => ({
+            type: 'upsert',
+            readModel: { type: 'test', id: '123', name: 'test' }
+          })
+        }
+      } as any
+
+      const db = new MockReadModelStoreWithErrors()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('created', '123', { name: 'test' })
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(true)
+    })
+
+    test('handles upsert operation save failure', async () => {
+      // Arrange
+      const projection = {
+        created: {
+          test: () => ({
+            type: 'upsert',
+            readModel: {
+              type: 'test',
+              id: '123',
+              name: 'test'
+            }
+          })
+        }
+      }
+
+      const db = new MockReadModelStoreWithErrors(false, true) // Fail on save
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('created', '123', { name: 'test' })
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('SAVE_VIEW_FAILED')
+        expect(result.error.message).toContain('SavereadModel failed')
+      }
+    })
+
+    test('handles projection function execution successfully', async () => {
+      // Arrange
+      const projection: Projection<
+        TestEvent,
+        TestReadModel,
+        ProjectionMap<TestEvent, TestReadModel>
+      > = {
+        created: {
+          test: ({ event }) => ({ type: 'test', id: event.id.value, name: event.payload.name })
+        },
+        deleted: {
+          test: () => undefined
+        },
+        updated: {
+          test: ({ readModel }) => {
+            readModel.name = 'updated'
+            return readModel
+          }
+        }
+      }
+
+      const db = new MockReadModelStore()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('updated', '123', { name: 'test' })
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(true)
+    })
+
+    test('handles save failure when projection returnsreadModel', async () => {
+      // Arrange
+      const projection: Projection<
+        TestEvent,
+        TestReadModel,
+        ProjectionMap<TestEvent, TestReadModel>
+      > = {
+        created: {
+          test: ({ event }) => ({ type: 'test', id: event.id.value, name: event.payload.name })
+        },
+        deleted: {
+          test: () => undefined
+        },
+        updated: {
+          test: ({ readModel }) => {
+            readModel.name = 'updated'
+            return readModel
+          }
+        }
+      }
+
+      const db = new MockReadModelStoreWithErrors(false, true) // Success on get, fail on save
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('updated', '123', { name: 'test' })
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('SAVE_VIEW_FAILED')
+        expect(result.error.message).toContain('SavereadModel failed')
+      }
+    })
+
+    test('handles projection returning undefined (no-op)', async () => {
+      // Arrange
+      const projection: Projection<
+        TestEvent,
+        TestReadModel,
+        ProjectionMap<TestEvent, TestReadModel>
+      > = {
+        created: {
+          test: ({ event }) => ({ type: 'test', id: event.id.value, name: event.payload.name })
+        },
+        deleted: {
+          test: () => undefined // Returns undefined, so no save operation
+        },
+        updated: {
+          test: ({ readModel }) => {
+            readModel.name = 'updated'
+            return readModel
+          }
+        }
+      }
+
+      const db = new MockReadModelStore()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('deleted', '123')
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(true) // Should succeed as nothing is saved
+    })
+
+    test('handles projection function throwing error', async () => {
+      // Arrange
+      const projection: Projection<
+        TestEvent,
+        TestReadModel,
+        ProjectionMap<TestEvent, TestReadModel>
+      > = {
+        created: {
+          test: () => {
+            throw new Error('Projection function error')
+          }
+        },
+        deleted: {
+          test: () => undefined
+        },
+        updated: {
+          test: ({ readModel }) => {
+            readModel.name = 'updated'
+            return readModel
+          }
+        }
+      }
+
+      const db = new MockReadModelStore()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('created', '123', { name: 'test' })
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('PROJECTION_EXECUTION_FAILED')
+        expect(result.error.message).toContain('Projection execution failed')
+      }
+    })
+
+    test('processes noop operation successfully', async () => {
+      // Arrange
+      const projection = {
+        created: {
+          test: (_params: any) => ({ type: 'mutate' })
+        }
+      }
+
+      const db = new MockReadModelStoreWithErrors()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('created', '123', { name: 'test' })
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(true)
+    })
+
+    test('handles upsert operation withoutreadModel property', async () => {
+      // Arrange
+      const projection = {
+        created: {
+          test: () => ({ type: 'upsert' }) as any // MissingreadModel property
+        }
+      }
+
+      const db = new MockReadModelStoreWithErrors()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('created', '123', { name: 'test' })
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(true) // Should succeed silently
+    })
+
+    test('handles delete operation without ids property', async () => {
+      // Arrange
+      const projection = {
+        created: {
+          test: () => ({ type: 'mutate' })
+        },
+        updated: {
+          test: () => ({ type: 'mutate' })
+        },
+        deleted: {
+          test: () => ({ type: 'delete' }) as any // Missing ids property
+        }
+      }
+
+      const db = new MockReadModelStoreWithErrors()
+      const projectFn = createProjectEventFnFactory(projection as any)(db)
+
+      const event = createTestEvent('deleted', '123')
+
+      // Act
+      const result = await projectFn(event)
+
+      // Assert
+      expect(result.ok).toBe(true) // Should succeed silently
+    })
+  })
+})

--- a/tests/fixtures/counter-app/features/counter/counter-reactor.ts
+++ b/tests/fixtures/counter-app/features/counter/counter-reactor.ts
@@ -1,0 +1,51 @@
+import { createEventReactor } from '../../../../../src/event/event-reactor-builder'
+import type { Policy, Projection, ProjectionMap } from '../../../../../src/types/event'
+import type { CounterCommand, CounterEvent, CounterReadModels } from './types'
+
+const policy: Policy<CounterEvent, CounterCommand> = {
+  created: () => null,
+  incremented: () => null,
+  decremented: () => null
+}
+
+const projectionMap = {
+  created: [
+    { readModel: 'counter' },
+    { readModel: 'achievement', where: (e: CounterEvent) => ({ counterId: e.id.value }) }
+  ],
+  incremented: [{ readModel: 'counter' }],
+  decremented: [{ readModel: 'counter' }]
+} satisfies ProjectionMap<CounterEvent, CounterReadModels>
+
+const projection: Projection<CounterEvent, CounterReadModels, typeof projectionMap> = {
+  created: {
+    counter: ({ event }) => ({
+      type: 'counter',
+      id: event.id.value,
+      count: event.payload.count
+    }),
+    achievement: ({ ctx, event }) => ({
+      type: 'achievement',
+      id: '1',
+      counterId: event.id.value,
+      level: 1,
+      achievedAt: ctx.timestamp
+    })
+  },
+  incremented: {
+    counter: ({ readModel }) => {
+      readModel.count += 1
+    }
+  },
+  decremented: {
+    counter: ({ readModel }) => {
+      readModel.count -= 1
+    }
+  }
+}
+
+export const counterReactor = createEventReactor<CounterEvent, CounterCommand, CounterReadModels>()
+  .type('counter')
+  .policy(policy)
+  .projectionWithMap(projection, projectionMap)
+  .build()

--- a/tests/fixtures/counter-app/features/counter/types.ts
+++ b/tests/fixtures/counter-app/features/counter/types.ts
@@ -1,4 +1,5 @@
 import type { AggregateId } from '../../../../../src/types/core'
+import type { AchievementReadModel, CounterReadModel } from '../../shared/readmodel'
 
 export type CounterId = AggregateId<'counter'>
 
@@ -17,3 +18,5 @@ export type CounterEvent =
   | { type: 'created'; id: CounterId; payload: { count: number } }
   | { type: 'incremented'; id: CounterId }
   | { type: 'decremented'; id: CounterId }
+
+export type CounterReadModels = CounterReadModel | AchievementReadModel

--- a/tests/fixtures/counter-app/features/counter2/counter2-reactor.ts
+++ b/tests/fixtures/counter-app/features/counter2/counter2-reactor.ts
@@ -1,0 +1,61 @@
+import { createEventReactor } from '../../../../../src/event/event-reactor-builder'
+import type { Policy, PolicyMap, Projection, ProjectionMap } from '../../../../../src/types/event'
+import type { CounterCommand, CounterEvent, CounterReadModels } from './types'
+
+const policyMap = {
+  created: [],
+  incremented: [],
+  decremented: []
+} satisfies PolicyMap<CounterEvent, CounterCommand>
+
+const policy: Policy<CounterEvent, CounterCommand, typeof policyMap> = {
+  created: () => null,
+  incremented: () => null,
+  decremented: () => null
+}
+
+const projectionMap = {
+  created: [
+    { readModel: 'counter' },
+    { readModel: 'achievement', where: (e: CounterEvent) => ({ counterId: e.id.value }) }
+  ],
+  incremented: [{ readModel: 'counter' }],
+  decremented: [{ readModel: 'counter' }]
+} satisfies ProjectionMap<CounterEvent, CounterReadModels>
+
+const projection: Projection<CounterEvent, CounterReadModels, typeof projectionMap> = {
+  created: {
+    counter: ({ event }) => {
+      return {
+        type: 'counter',
+        id: event.id.value,
+        count: event.payload.count
+      }
+    },
+    achievement: ({ ctx, event }) => {
+      return {
+        type: 'achievement',
+        id: '1',
+        counterId: event.id.value,
+        level: 1,
+        achievedAt: ctx.timestamp
+      }
+    }
+  },
+  incremented: {
+    counter: ({ readModel }) => {
+      readModel.count += 1
+    }
+  },
+  decremented: {
+    counter: ({ readModel }) => {
+      readModel.count -= 1
+    }
+  }
+}
+
+export const counterReactor = createEventReactor<CounterEvent, CounterCommand, CounterReadModels>()
+  .type('counter')
+  .policyWithMap(policy, policyMap)
+  .projectionWithMap(projection, projectionMap)
+  .build()

--- a/tests/fixtures/counter-app/features/counter2/types.ts
+++ b/tests/fixtures/counter-app/features/counter2/types.ts
@@ -1,4 +1,5 @@
 import type { AggregateId } from '../../../../../src/types/core'
+import type { AchievementReadModel, CounterReadModel } from '../../shared/readmodel'
 
 export type CounterId = AggregateId<'counter'>
 
@@ -17,3 +18,5 @@ export type CounterEvent =
   | { type: 'created'; id: CounterId; payload: { count: number } }
   | { type: 'incremented'; id: CounterId }
   | { type: 'decremented'; id: CounterId }
+
+export type CounterReadModels = CounterReadModel | AchievementReadModel

--- a/tests/fixtures/counter-app/shared/readmodel/achievement-read-model.ts
+++ b/tests/fixtures/counter-app/shared/readmodel/achievement-read-model.ts
@@ -1,0 +1,7 @@
+export type AchievementReadModel = {
+  type: 'achievement'
+  id: string
+  counterId: string
+  level: number
+  achievedAt: Date
+}

--- a/tests/fixtures/counter-app/shared/readmodel/counter-read-model.ts
+++ b/tests/fixtures/counter-app/shared/readmodel/counter-read-model.ts
@@ -1,0 +1,5 @@
+export type CounterReadModel = {
+  type: 'counter'
+  id: string
+  count: number
+}

--- a/tests/fixtures/counter-app/shared/readmodel/index.ts
+++ b/tests/fixtures/counter-app/shared/readmodel/index.ts
@@ -1,0 +1,2 @@
+export * from './achievement-read-model'
+export * from './counter-read-model'


### PR DESCRIPTION
## Summary

Introduce an event-driven framework to dispatch domain events and project them into read models. This adds an event bus, event handler abstraction, a reactor builder for policies/projections, and in-memory adapters for dispatching and read model storage. Comprehensive unit tests and example fixtures for the counter app are included.

## Changes

- Add event modules
  - `src/event/event-bus.ts`
  - `src/event/event-handler.ts`
  - `src/event/event-reactor-builder.ts`
  - `src/event/fn/dispatch-event.ts`
  - `src/event/fn/project-event.ts`
- Add adapters
  - `src/adapter/command-dispatcher-mock.ts`
  - `src/adapter/read-model-store-in-memory.ts`
- Add tests for event modules
  - `tests/event/event-bus.test.ts`
  - `tests/event/event-handler.test.ts`
  - `tests/event/event-reactor-builder.test.ts`
  - `tests/event/fn/dispatch-event.test.ts`
  - `tests/event/fn/project-event.test.ts`
- Add example fixtures for reactors and read models
  - `tests/fixtures/counter-app/features/counter/counter-reactor.ts`
  - `tests/fixtures/counter-app/features/counter2/counter2-reactor.ts`
  - `tests/fixtures/counter-app/shared/readmodel/achievement-read-model.ts`
  - `tests/fixtures/counter-app/shared/readmodel/counter-read-model.ts`
  - `tests/fixtures/counter-app/shared/readmodel/index.ts`
- Update types for counter features
  - `tests/fixtures/counter-app/features/counter/types.ts`
  - `tests/fixtures/counter-app/features/counter2/types.ts`

## Testing

- [x] Unit tests added for event bus, handler, reactor builder, and dispatch/project functions
- [x] Example fixtures updated and covered by tests
- [ ] Manual verification in sample app
- [ ] Integration tests

## Related Issues

None

## Notes

- Base: `main` ← `feat/event-handler-implemention`
- No breaking changes expected.
- To run tests locally: `bun test`