### PR TITLE
update: Inject EventStore directly and introduce event reactor framework

### DIFF
--- a/src/command/aggregate-builder.ts
+++ b/src/command/aggregate-builder.ts
@@ -1,9 +1,9 @@
 import { produce } from 'immer'
 import type {
   Aggregate,
-  DeciderMap,
   EventDecider,
   EventDeciderFn,
+  EventDeciderMap,
   Reducer,
   ReducerFn,
   ReducerMap
@@ -16,8 +16,8 @@ import { createAcceptsCommand, createAcceptsEvent } from './helpers/create-accep
  */
 type BuilderValue<S extends State, C extends Command, E extends DomainEvent> = {
   type: S['id']['type']
-  decider: EventDecider<S, C, E> | EventDecider<S, C, E, DeciderMap<S, C>>
-  deciderMap?: DeciderMap<S, C>
+  decider: EventDecider<S, C, E> | EventDecider<S, C, E, EventDeciderMap<S, C>>
+  deciderMap?: EventDeciderMap<S, C>
   reducer: Reducer<S, E> | Reducer<S, E, ReducerMap<S, E>>
   reducerMap?: ReducerMap<S, E>
 }
@@ -52,7 +52,7 @@ export interface IAggregateBuilder<
   deciderWithMap(
     this: IAggregateBuilder<'hasType', S, C, E>,
     value: EventDecider<S, C, E>,
-    transitionMap: DeciderMap<S, C>
+    transitionMap: EventDeciderMap<S, C>
   ): IAggregateBuilder<'hasDecider', S, C, E>
 
   reducer(
@@ -82,7 +82,7 @@ function isRequiredBuilderValue<S extends State, C extends Command, E extends Do
  * Helper to safely convert any decider to EventDeciderFn
  */
 function createEventDeciderFn<S extends State, C extends Command, E extends DomainEvent>(
-  decider: EventDecider<S, C, E> | EventDecider<S, C, E, DeciderMap<S, C>>
+  decider: EventDecider<S, C, E> | EventDecider<S, C, E, EventDeciderMap<S, C>>
 ): EventDeciderFn<S, C, E> {
   return fromEventDecider(decider as EventDecider<S, C, E>)
 }
@@ -177,7 +177,7 @@ export class AggregateBuilder<
     return this.withValue<'hasDecider', { decider: EventDecider<S, C, E> }>({ decider })
   }
 
-  deciderWithMap<DM extends DeciderMap<S, C>>(
+  deciderWithMap<DM extends EventDeciderMap<S, C>>(
     this: AggregateBuilder<'hasType', S, C, E>,
     decider: EventDecider<S, C, E, DM>,
     deciderMap: DM
@@ -218,7 +218,7 @@ export class AggregateBuilder<
       throw new Error('Aggregate is not ready to build. Missing required properties.')
     }
 
-    const deciderMap: DeciderMap<S, C> = this.value.deciderMap ?? ({} as DeciderMap<S, C>)
+    const deciderMap: EventDeciderMap<S, C> = this.value.deciderMap ?? ({} as EventDeciderMap<S, C>)
     const acceptsCommand = createAcceptsCommand<S, C>(deciderMap)
 
     const reducerMap: ReducerMap<S, E> = this.value.reducerMap ?? ({} as ReducerMap<S, E>)

--- a/src/command/command-handler.ts
+++ b/src/command/command-handler.ts
@@ -18,10 +18,10 @@ function createCommandHandlerFactory<
   D extends CommandHandlerDeps
 >(aggregate: Aggregate<S, C, E>): CommandHandlerFactory<D> {
   return (deps: D) => {
-    const replayFn = createReplayEventFnFactory<S, E, D>(aggregate.reducer)(deps)
+    const replayFn = createReplayEventFnFactory<S, E>(aggregate.reducer)(deps.eventStore)
     const initFn = createInitEventFnFactory<S, C, E>(aggregate.decider, aggregate.reducer)()
     const applyFn = createApplyEventFnFactory<S, C, E>(aggregate.decider, aggregate.reducer)()
-    const saveFn = createSaveEventFnFactory<S, E, D>()(deps)
+    const saveFn = createSaveEventFnFactory<S, E>()(deps.eventStore)
 
     // Handles aggregate creation or update based on the incoming command
     return async (command: Command): CommandResult => {

--- a/src/command/helpers/create-accepts.ts
+++ b/src/command/helpers/create-accepts.ts
@@ -2,7 +2,7 @@ import type {
   AcceptsCommandFn,
   AcceptsEventFn,
   ApplyEventType,
-  DeciderMap,
+  EventDeciderMap,
   ReducerMap
 } from '../../types/command'
 import type { Command, DomainEvent, State } from '../../types/core'
@@ -22,7 +22,7 @@ const isMapVoid = <T extends { type: string }>(map: Record<string, string[]>, ke
 }
 
 export const createAcceptsCommand = <S extends State, C extends Command>(
-  map: DeciderMap<S, C>
+  map: EventDeciderMap<S, C>
 ): AcceptsCommandFn<S, C> => {
   return (state: S, command: C, eventType: ApplyEventType) => {
     // If no map is provided, accept any command for any state.

--- a/src/types/command/event-decider-fn.ts
+++ b/src/types/command/event-decider-fn.ts
@@ -4,7 +4,7 @@ export type EventDeciderContext = {
   readonly timestamp: Date
 }
 
-export type DeciderMap<S extends State, C extends Command> = {
+export type EventDeciderMap<S extends State, C extends Command> = {
   [K in C['type']]: S['type'][]
 }
 

--- a/src/types/command/event-decider.ts
+++ b/src/types/command/event-decider.ts
@@ -1,11 +1,11 @@
 import type { Command, DomainEvent, State } from '../core'
-import type { DeciderMap, EventDeciderFn } from './event-decider-fn'
+import type { EventDeciderFn, EventDeciderMap } from './event-decider-fn'
 
 export type EventDecider<
   S extends State,
   C extends Command,
   E extends DomainEvent,
-  DM extends DeciderMap<S, C> = never
+  DM extends EventDeciderMap<S, C> = never
 > = [DM] extends [never]
   ? {
       [K in C['type']]: EventDeciderFn<S, Extract<C, { type: K }>, E>

--- a/tests/command/aggregate-builder.test.ts
+++ b/tests/command/aggregate-builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { createAggregate, fromReducer } from '../../src/command/aggregate-builder'
-import type { DeciderMap, EventDecider, Reducer, ReducerMap } from '../../src/types/command'
+import type { EventDecider, EventDeciderMap, Reducer, ReducerMap } from '../../src/types/command'
 import type { AggregateId } from '../../src/types/core'
 
 // Test types
@@ -76,7 +76,7 @@ describe('[command] aggregate builder', () => {
 
     test('builds functioning aggregate with decider and reducer maps', () => {
       // Arrange
-      const deciderMap: DeciderMap<TestState, TestCommand> = {
+      const deciderMap: EventDeciderMap<TestState, TestCommand> = {
         create: [],
         update: ['active'],
         deactivate: ['active', 'inactive']
@@ -103,7 +103,7 @@ describe('[command] aggregate builder', () => {
 
     test('builds functioning aggregate with decider map and reducer', () => {
       // Arrange
-      const deciderMap: DeciderMap<TestState, TestCommand> = {
+      const deciderMap: EventDeciderMap<TestState, TestCommand> = {
         create: [],
         update: ['active'],
         deactivate: ['active', 'inactive']

--- a/tests/command/fn/replay-event.test.ts
+++ b/tests/command/fn/replay-event.test.ts
@@ -10,10 +10,8 @@ describe('[command] replay event function', () => {
   describe('createReplayEventFnFactory', () => {
     test('should return a function when counter aggregate is provided', () => {
       // Act
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+      const eventStore = new EventStoreInMemory()
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(eventStore)
 
       // Assert
       expect(replayEventFn).toBeDefined()
@@ -21,10 +19,8 @@ describe('[command] replay event function', () => {
 
     test('should return a function when counter2 aggregate is provided', () => {
       // Act
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const replayEventFn = createReplayEventFnFactory(counter2.reducer)(deps)
+      const eventStore = new EventStoreInMemory()
+      const replayEventFn = createReplayEventFnFactory(counter2.reducer)(eventStore)
 
       // Assert
       expect(replayEventFn).toBeDefined()
@@ -34,14 +30,12 @@ describe('[command] replay event function', () => {
   describe('ReplayEventFn', () => {
     test('should return a result with the state when the event is found', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+      const eventStore = new EventStoreInMemory()
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(eventStore)
 
       // Act
       const id = zeroId('counter')
-      await deps.eventStore.saveEvent({
+      await eventStore.saveEvent({
         type: 'created',
         id,
         payload: { count: 0 },
@@ -64,21 +58,19 @@ describe('[command] replay event function', () => {
 
     test('should return a result with the state when the event and snapshot is found', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+      const eventStore = new EventStoreInMemory()
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(eventStore)
 
       // Act
       const id = zeroId('counter')
-      await deps.eventStore.saveEvent({
+      await eventStore.saveEvent({
         type: 'created',
         id,
         payload: { count: 0 },
         version: 1,
         timestamp: new Date()
       })
-      await deps.eventStore.saveSnapshot({
+      await eventStore.saveSnapshot({
         type: 'active',
         id,
         count: 0,
@@ -101,17 +93,15 @@ describe('[command] replay event function', () => {
 
     test('should return a error when the snapshot can not be loaded', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      deps.eventStore.getSnapshot = async () => {
+      const eventStore = new EventStoreInMemory()
+      eventStore.getSnapshot = async () => {
         throw new Error('error')
       }
-      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(eventStore)
 
       // Act
       const id = zeroId('counter')
-      await deps.eventStore.saveEvent({
+      await eventStore.saveEvent({
         type: 'created',
         id,
         payload: { count: 0 },
@@ -130,13 +120,11 @@ describe('[command] replay event function', () => {
 
     test('should return a error when the events can not be loaded', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      deps.eventStore.getEvents = async () => {
+      const eventStore = new EventStoreInMemory()
+      eventStore.getEvents = async () => {
         throw new Error('error')
       }
-      const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+      const replayEventFn = createReplayEventFnFactory(counter.reducer)(eventStore)
 
       // Act
       const id = zeroId('counter')
@@ -153,10 +141,8 @@ describe('[command] replay event function', () => {
 
   test('should return a error when no events are stored', async () => {
     // Arrange
-    const deps = {
-      eventStore: new EventStoreInMemory()
-    }
-    const replayEventFn = createReplayEventFnFactory(counter.reducer)(deps)
+    const eventStore = new EventStoreInMemory()
+    const replayEventFn = createReplayEventFnFactory(counter.reducer)(eventStore)
 
     // Act
     const id = zeroId('counter')
@@ -172,17 +158,15 @@ describe('[command] replay event function', () => {
 
   test('should return a error when the reducer returns void', async () => {
     // Arrange
-    const deps = {
-      eventStore: new EventStoreInMemory()
-    }
+    const eventStore = new EventStoreInMemory()
     const reducer = (_: unknown): CounterState => {
       throw new Error('error')
     }
-    const replayEventFn = createReplayEventFnFactory(reducer)(deps)
+    const replayEventFn = createReplayEventFnFactory(reducer)(eventStore)
 
     // Act
     const id = zeroId('counter') as AggregateId<'counter'>
-    await deps.eventStore.saveEvent({
+    await eventStore.saveEvent({
       type: 'created',
       id,
       payload: { count: 0 },

--- a/tests/command/fn/save-event.test.ts
+++ b/tests/command/fn/save-event.test.ts
@@ -6,12 +6,10 @@ import type { CounterEvent, CounterState } from '../../fixtures/counter-app/feat
 
 describe('[command] save event function', () => {
   describe('createSaveEventFnFactory', () => {
-    test('should return a function when deps is provided', () => {
+    test('should return a function when eventStore is provided', () => {
       // Act
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const saveEventFn = createSaveEventFnFactory()(deps)
+      const eventStore = new EventStoreInMemory()
+      const saveEventFn = createSaveEventFnFactory()(eventStore)
 
       // Assert
       expect(saveEventFn).toBeDefined()
@@ -21,10 +19,8 @@ describe('[command] save event function', () => {
   describe('SaveEventFn', () => {
     test('should return ok when the event is saved', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const saveEventFn = createSaveEventFnFactory()(deps)
+      const eventStore = new EventStoreInMemory()
+      const saveEventFn = createSaveEventFnFactory()(eventStore)
 
       // Act
       const id = zeroId('counter')
@@ -49,10 +45,8 @@ describe('[command] save event function', () => {
 
     test('should return ok when the event and shapshot are saved', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const saveEventFn = createSaveEventFnFactory()(deps)
+      const eventStore = new EventStoreInMemory()
+      const saveEventFn = createSaveEventFnFactory()(eventStore)
 
       const id = zeroId('counter')
       const createEvent: ExtendedDomainEvent<CounterEvent> = {
@@ -74,7 +68,7 @@ describe('[command] save event function', () => {
       )
       const events = [createEvent, ...incrementEvents]
       for (const event of events) {
-        await deps.eventStore.saveEvent(event)
+        await eventStore.saveEvent(event)
       }
 
       // Act
@@ -91,7 +85,7 @@ describe('[command] save event function', () => {
         timestamp: new Date()
       }
       const res = await saveEventFn(state, event)
-      const snapshot = await deps.eventStore.getSnapshot(id)
+      const snapshot = await eventStore.getSnapshot(id)
 
       // Assert
       expect(res.ok).toBe(true)
@@ -106,13 +100,11 @@ describe('[command] save event function', () => {
 
     test('should return error when the snapshot can not be saved', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      deps.eventStore.saveSnapshot = async () => {
+      const eventStore = new EventStoreInMemory()
+      eventStore.saveSnapshot = async () => {
         throw new Error('error')
       }
-      const saveEventFn = createSaveEventFnFactory()(deps)
+      const saveEventFn = createSaveEventFnFactory()(eventStore)
 
       const id = zeroId('counter')
       const createEvent: ExtendedDomainEvent<CounterEvent> = {
@@ -134,7 +126,7 @@ describe('[command] save event function', () => {
       )
       const events = [createEvent, ...incrementEvents]
       for (const event of events) {
-        await deps.eventStore.saveEvent(event)
+        await eventStore.saveEvent(event)
       }
 
       // Act
@@ -162,10 +154,8 @@ describe('[command] save event function', () => {
 
     test('should return error when the state and event versions mismatch', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const saveEventFn = createSaveEventFnFactory()(deps)
+      const eventStore = new EventStoreInMemory()
+      const saveEventFn = createSaveEventFnFactory()(eventStore)
 
       // Act
       const id = zeroId('counter')
@@ -194,13 +184,11 @@ describe('[command] save event function', () => {
 
     test('should return error when the last event version can not be loaded', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      deps.eventStore.getLastEventVersion = async () => {
+      const eventStore = new EventStoreInMemory()
+      eventStore.getLastEventVersion = async () => {
         throw new Error('error')
       }
-      const saveEventFn = createSaveEventFnFactory()(deps)
+      const saveEventFn = createSaveEventFnFactory()(eventStore)
 
       // Act
       const id = zeroId('counter')
@@ -229,10 +217,8 @@ describe('[command] save event function', () => {
 
     test('should return error when the event version is not the next version', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      const saveEventFn = createSaveEventFnFactory()(deps)
+      const eventStore = new EventStoreInMemory()
+      const saveEventFn = createSaveEventFnFactory()(eventStore)
 
       // Act
       const id = zeroId('counter')
@@ -261,13 +247,11 @@ describe('[command] save event function', () => {
 
     test('should return a error when the events can not be loaded', async () => {
       // Arrange
-      const deps = {
-        eventStore: new EventStoreInMemory()
-      }
-      deps.eventStore.saveEvent = async () => {
+      const eventStore = new EventStoreInMemory()
+      eventStore.saveEvent = async () => {
         throw new Error('error')
       }
-      const saveEventFn = createSaveEventFnFactory()(deps)
+      const saveEventFn = createSaveEventFnFactory()(eventStore)
 
       // Act
       const id = zeroId('counter')

--- a/tests/command/helpers/create-accepts.test.ts
+++ b/tests/command/helpers/create-accepts.test.ts
@@ -4,7 +4,7 @@ import {
   createAcceptsCommand,
   createAcceptsEvent
 } from '../../../src/command/helpers/create-accepts'
-import type { DeciderMap, ReducerMap } from '../../../src/types/command'
+import type { EventDeciderMap, ReducerMap } from '../../../src/types/command'
 import type { AggregateId } from '../../../src/types/core'
 
 type TestState =
@@ -27,7 +27,7 @@ type TestEvent =
 describe('[command] create accepts function', () => {
   describe('createAcceptsCommandFn', () => {
     test('accepts all command and state combinations when empty map is provided', () => {
-      const emptyMap = {} as DeciderMap<TestState, TestCommand>
+      const emptyMap = {} as EventDeciderMap<TestState, TestCommand>
       const acceptsCommand = createAcceptsCommand(emptyMap)
 
       const id = zeroId('test')
@@ -46,7 +46,7 @@ describe('[command] create accepts function', () => {
     })
 
     test('accepts commands with empty array definition for create event type', () => {
-      const deciderMap: DeciderMap<TestState, TestCommand> = {
+      const deciderMap: EventDeciderMap<TestState, TestCommand> = {
         create: [], // create command only allowed during initial creation (no existing state)
         update: ['active'], // update command only accepted in active state
         activate: ['initial'], // activate command only accepted in initial state
@@ -63,7 +63,7 @@ describe('[command] create accepts function', () => {
     })
 
     test('rejects commands with state array definition for create event type', () => {
-      const deciderMap: DeciderMap<TestState, TestCommand> = {
+      const deciderMap: EventDeciderMap<TestState, TestCommand> = {
         create: [],
         update: ['active'],
         activate: ['initial'],
@@ -80,7 +80,7 @@ describe('[command] create accepts function', () => {
     })
 
     test('accepts commands in allowed states for update event type', () => {
-      const deciderMap: DeciderMap<TestState, TestCommand> = {
+      const deciderMap: EventDeciderMap<TestState, TestCommand> = {
         create: [],
         update: ['active'],
         activate: ['initial'],
@@ -101,7 +101,7 @@ describe('[command] create accepts function', () => {
     })
 
     test('rejects commands in disallowed states for update event type', () => {
-      const deciderMap: DeciderMap<TestState, TestCommand> = {
+      const deciderMap: EventDeciderMap<TestState, TestCommand> = {
         create: [],
         update: ['active'],
         activate: ['initial'],
@@ -122,7 +122,7 @@ describe('[command] create accepts function', () => {
     })
 
     test('rejects commands not defined in map for all states and event types', () => {
-      const deciderMap: DeciderMap<TestState, TestCommand> = {
+      const deciderMap: EventDeciderMap<TestState, TestCommand> = {
         create: [],
         update: ['active'],
         activate: ['initial'],

--- a/tests/fixtures/counter-app/features/counter2/counter2-aggregate.ts
+++ b/tests/fixtures/counter-app/features/counter2/counter2-aggregate.ts
@@ -13,7 +13,7 @@ const deciderMap = {
   decrement: ['active']
 } satisfies EventDeciderMap<CounterState, CounterCommand>
 
-const decider: EventDecider<CounterState, CounterCommand, CounterEvent> = {
+const decider: EventDecider<CounterState, CounterCommand, CounterEvent, typeof deciderMap> = {
   create: ({ command }) => {
     return {
       type: 'created',

--- a/tests/fixtures/counter-app/features/counter2/counter2-aggregate.ts
+++ b/tests/fixtures/counter-app/features/counter2/counter2-aggregate.ts
@@ -1,7 +1,7 @@
 import { createAggregate } from '../../../../../src/command/aggregate-builder'
 import type {
-  DeciderMap,
   EventDecider,
+  EventDeciderMap,
   Reducer,
   ReducerMap
 } from '../../../../../src/types/command'
@@ -11,7 +11,7 @@ const deciderMap = {
   create: [],
   increment: ['active'],
   decrement: ['active']
-} satisfies DeciderMap<CounterState, CounterCommand>
+} satisfies EventDeciderMap<CounterState, CounterCommand>
 
 const decider: EventDecider<CounterState, CounterCommand, CounterEvent> = {
   create: ({ command }) => {


### PR DESCRIPTION
## Summary

Refactors command handling to inject EventStore directly into core functions, and introduces an event reactor framework (event bus, handlers, builder) with supporting adapters and tests.

## Changes

- Refactor createReplayEventFnFactory and createSaveEventFnFactory to accept EventStore directly
- Update command handler factory to use deps.eventStore in place of full deps injection
- Rename DeciderMap to EventDeciderMap across command types and APIs
- Add event system: event-bus, event-handler, event-reactor-builder, dispatch-event, and project-event functions
- Add adapters: CommandDispatcherMock and ReadModelStoreInMemory
- Add comprehensive tests for event bus/handler/builder and projection/dispatch functions; update existing command tests
- Update counter app fixtures with reactors and shared read models

## Testing

- [x] Unit tests executed

## Related Issues


## Notes

- Breaking change: dependency injection signatures changed for replay/save factories; EventStore must be passed directly
- Breaking change: DeciderMap renamed to EventDeciderMap; update imports and generic usages
- Migration: adjust aggregate and test code to new types, and pass eventStore into factory call sites