### PR TITLE
feat: reintroduce query types and restore strongly-typed ReadModelStore

### DIFF
--- a/src/types/adapter/read-model-store.ts
+++ b/src/types/adapter/read-model-store.ts
@@ -41,9 +41,15 @@ export type QueryOption<T extends ReadModel> = {
   range?: RangeOption
 }
 
-export interface ReadModelStore {
-  findMany<T extends ReadModel>(type: T['type'], options: QueryOption<T>): Promise<T[]>
-  findById<T extends ReadModel>(type: T['type'], id: string): Promise<T | null>
-  save<T extends ReadModel>(model: T): Promise<void>
-  delete<T extends ReadModel>(model: T): Promise<void>
+export interface ReadModelStore<M extends ReadModel = ReadModel> {
+  findMany<T extends M['type']>(
+    type: T,
+    options: QueryOption<M extends { type: T } ? M : never>
+  ): Promise<(M extends { type: T } ? M : never)[]>
+  findById<T extends M['type']>(
+    type: T,
+    id: string
+  ): Promise<(M extends { type: T } ? M : never) | null>
+  save(model: M): Promise<void>
+  delete(model: M): Promise<void>
 }

--- a/src/types/adapter/read-model-store.ts
+++ b/src/types/adapter/read-model-store.ts
@@ -41,15 +41,16 @@ export type QueryOption<T extends ReadModel> = {
   range?: RangeOption
 }
 
+export type ModelOfType<M extends ReadModel, T extends M['type']> = M extends { type: T }
+  ? M
+  : never
+
 export interface ReadModelStore<M extends ReadModel = ReadModel> {
   findMany<T extends M['type']>(
     type: T,
-    options: QueryOption<M extends { type: T } ? M : never>
-  ): Promise<(M extends { type: T } ? M : never)[]>
-  findById<T extends M['type']>(
-    type: T,
-    id: string
-  ): Promise<(M extends { type: T } ? M : never) | null>
+    options: QueryOption<ModelOfType<M, T>>
+  ): Promise<ModelOfType<M, T>[]>
+  findById<T extends M['type']>(type: T, id: string): Promise<ModelOfType<M, T> | null>
   save(model: M): Promise<void>
   delete(model: M): Promise<void>
 }

--- a/src/types/core/index.ts
+++ b/src/types/core/index.ts
@@ -1,5 +1,6 @@
 export * from './aggregate-id'
 export * from './command'
 export * from './domain-event'
+export * from './query'
 export * from './read-model'
 export * from './state'

--- a/src/types/core/query.ts
+++ b/src/types/core/query.ts
@@ -1,0 +1,15 @@
+import type { AppError } from '../utils/app-error'
+import type { AsyncResult } from '../utils/result'
+
+export type Query = {
+  readonly type: string
+}
+
+export type QueryResultData = Record<string, unknown>
+
+export type QueryResultPayload<T extends QueryResultData = QueryResultData> = {
+  type: string
+  data: T
+}
+
+export type QueryResult = AsyncResult<QueryResultPayload, AppError>

--- a/src/types/framework/index.ts
+++ b/src/types/framework/index.ts
@@ -1,2 +1,3 @@
 export * from './command-bus'
 export * from './event-bus'
+export * from './query-bus'

--- a/src/types/framework/query-bus.ts
+++ b/src/types/framework/query-bus.ts
@@ -1,0 +1,12 @@
+import type { ReadModelStore } from '../adapter/read-model-store'
+import type { Query, QueryResult } from '../core/query'
+
+export interface QueryHandlerDeps {
+  readModelStore: ReadModelStore
+}
+
+export type QueryHandler = (query: Query) => QueryResult
+
+export type QueryHandlerMiddleware = (query: Query, next: QueryHandler) => QueryResult
+
+export type QueryBus = QueryHandler

--- a/src/types/query/index.ts
+++ b/src/types/query/index.ts
@@ -1,0 +1,3 @@
+export * from './query-resolver'
+export * from './query-source'
+export * from './resolver-fn'

--- a/src/types/query/query-resolver.ts
+++ b/src/types/query/query-resolver.ts
@@ -1,0 +1,10 @@
+import type { Query, QueryResultData } from '../core'
+import type { ResolverFn } from './resolver-fn'
+
+export type QueryResolver<Q extends Query, QR extends QueryResultData, D> = {
+  type: Q['type']
+  resolver: ResolverFn<Q, QR, D>
+}
+
+// biome-ignore lint: To enable a generic QueryResolver type for utility and type inference purposes.
+export type AnyQueryResolver = QueryResolver<any, any, any>

--- a/src/types/query/query-resolver.ts
+++ b/src/types/query/query-resolver.ts
@@ -2,9 +2,5 @@ import type { Query, QueryResultData } from '../core'
 import type { ResolverFn } from './resolver-fn'
 
 export type QueryResolver<Q extends Query, QR extends QueryResultData, D> = {
-  type: Q['type']
-  resolver: ResolverFn<Q, QR, D>
+  [K in Q['type']]: ResolverFn<Extract<Q, { type: K }>, Extract<QR, { type: K }>, D>
 }
-
-// biome-ignore lint: To enable a generic QueryResolver type for utility and type inference purposes.
-export type AnyQueryResolver = QueryResolver<any, any, any>

--- a/src/types/query/query-source.ts
+++ b/src/types/query/query-source.ts
@@ -1,0 +1,10 @@
+import type { Query, QueryResultData } from '../core'
+import type { ResolverFn } from './resolver-fn'
+
+export type QuerySource<Q extends Query, QR extends QueryResultData, D> = {
+  type: Q['type']
+  queryResolver: ResolverFn<Q, QR, D>
+}
+
+// biome-ignore lint: To enable a generic Aggregate type for utility and type inference purposes.
+export type AnyQuerySource = QuerySource<any, any, any>

--- a/src/types/query/resolver-fn.ts
+++ b/src/types/query/resolver-fn.ts
@@ -1,0 +1,15 @@
+import type { Query, QueryResultData } from '../core'
+
+export type ResolverContext = {
+  readonly timestamp: Date
+}
+
+export type ResolverParams<Q extends Query, D> = {
+  ctx: ResolverContext
+  query: Q
+  deps: D
+}
+
+export type ResolverFn<Q extends Query, QR extends QueryResultData, D> = (
+  params: ResolverParams<Q, D>
+) => Promise<QR>

--- a/src/types/utils/app-error.ts
+++ b/src/types/utils/app-error.ts
@@ -1,4 +1,5 @@
 export type AppError = {
   code: string
   message: string
+  cause?: unknown
 }


### PR DESCRIPTION
## Summary

This PR reintroduces the query-related types and interfaces that were previously removed, restoring support for a more structured query handling mechanism. It also brings back the `ModelOfType` utility to enforce stronger type safety in `ReadModelStore`.

## Changes

- Restored `ModelOfType` utility type in `src/types/adapter/read-model-store.ts`.
- Updated `ReadModelStore` interface to use `ModelOfType` for stricter type inference.
- Re-added `src/types/core/query.ts` and its export from `src/types/core/index.ts`.
- Re-added `src/types/framework/query-bus.ts` and its export from `src/types/framework/index.ts`.
- Added back query-related files:
  - `src/types/query/query-resolver.ts`
  - `src/types/query/query-source.ts`
  - `src/types/query/resolver-fn.ts`
- Reintroduced `cause` property in `AppError` type for improved error context.

## Testing

- [x] TypeScript type checks pass.
- [x] Existing unit tests verified.

## Notes

This change restores previously removed functionality for query support, ensuring backward compatibility for consumers depending on these types and interfaces.
