### PR TITLE
fix: correct type order in EventReactor and related functions

### DIFF
--- a/src/event/event-reactor-builder.ts
+++ b/src/event/event-reactor-builder.ts
@@ -67,7 +67,7 @@ export interface IEventReactorBuilder<
     transitionMap: ProjectionMap<E, RM>
   ): IEventReactorBuilder<'complete', E, C, RM>
 
-  build(this: IEventReactorBuilder<'complete', E, C, RM>): EventReactor<C, E, RM>
+  build(this: IEventReactorBuilder<'complete', E, C, RM>): EventReactor<E, C, RM>
 }
 
 /**
@@ -233,7 +233,7 @@ export class EventReactorBuilder<
     return new EventReactorBuilder<NS, E, C, RM>(newValue)
   }
 
-  build(this: EventReactorBuilder<'complete', E, C, RM>): EventReactor<C, E, RM> {
+  build(this: EventReactorBuilder<'complete', E, C, RM>): EventReactor<E, C, RM> {
     if (!isRequiredBuilderValue(this.value)) {
       throw new Error('EventReactor is not ready to build. Missing required properties.')
     }

--- a/src/event/fn/project-event.ts
+++ b/src/event/fn/project-event.ts
@@ -23,13 +23,6 @@ export function createProjectEventFnFactory<E extends DomainEvent>(
           message: `Event type must be string, got: ${typeof eventType}`
         })
       }
-      // 型安全のため eventType を keyof ProjectionFn<E, ReadModel> として扱う
-      if (!(eventType in projection)) {
-        return err({
-          code: 'EVENT_TYPE_NOT_FOUND',
-          message: `Event type ${eventType} not found`
-        })
-      }
       const definitions = projection[eventType as keyof typeof projection]
       if (!definitions) {
         return err({

--- a/src/types/event/event-reactor.ts
+++ b/src/types/event/event-reactor.ts
@@ -2,7 +2,7 @@ import type { Command, DomainEvent, ReadModel } from '../core'
 import type { PolicyFn } from './policy-fn'
 import type { ProjectionFn } from './projection-fn'
 
-export type EventReactor<C extends Command, E extends DomainEvent, RM extends ReadModel> = {
+export type EventReactor<E extends DomainEvent, C extends Command, RM extends ReadModel> = {
   type: C['id']['type']
   policy: PolicyFn<E, C>
   projection: ProjectionFn<E, RM>

--- a/tests/command/aggregate-builder.test.ts
+++ b/tests/command/aggregate-builder.test.ts
@@ -143,7 +143,7 @@ describe('[command] aggregate builder', () => {
       expect(typeof aggregate.reducer).toBe('function')
     })
 
-    test('created aggregate processes commands correctly', () => {
+    test('created aggregate processes commands correctly', async () => {
       // Arrange
       const aggregate = createAggregate<TestState, TestCommand, TestEvent>()
         .type('test')
@@ -161,14 +161,16 @@ describe('[command] aggregate builder', () => {
       const ctx = { timestamp: new Date() }
 
       // Act
-      const event = aggregate.decider({ ctx, state: mockState, command })
+      const event = aggregate.decider({ ctx, state: mockState, command, deps: {} })
 
       // Assert
       expect(event).toBeDefined()
-      expect(event.id).toEqual(testId('123'))
-      expect(event.type).toBe('created')
-      if (event.type === 'created') {
-        expect(event.payload).toEqual({ value: 42 })
+      // Handle potential Promise
+      const resolvedEvent = await Promise.resolve(event)
+      expect(resolvedEvent.id).toEqual(testId('123'))
+      expect(resolvedEvent.type).toBe('created')
+      if (resolvedEvent.type === 'created') {
+        expect(resolvedEvent.payload).toEqual({ value: 42 })
       }
     })
 

--- a/tests/command/command-handler.test.ts
+++ b/tests/command/command-handler.test.ts
@@ -325,7 +325,7 @@ describe('[command] command handler', () => {
         eventStore: new EventStoreInMemory()
       }
       const handlers = createCommandHandlers(deps, [testAggregate])
-      const commandHandler = handlers[testAggregate.type]
+      const commandHandler = handlers[testAggregate.type]!
 
       // Act
       await commandHandler(createCommand)
@@ -351,12 +351,12 @@ describe('[command] command handler', () => {
 
       // First create the aggregate
       const handlers = createCommandHandlers(deps, [counter])
-      const commandHandler = handlers[counter.type]
+      const commandHandler = handlers[counter.type]!
       await commandHandler(createCommand)
 
       // Replace with test aggregate after creation
       const testHandlers = createCommandHandlers(deps, [testAggregate])
-      const testHandler = testHandlers[testAggregate.type]
+      const testHandler = testHandlers[testAggregate.type]!
 
       // Act - Update the existing aggregate
       await testHandler(incrementCommand)
@@ -378,7 +378,7 @@ describe('[command] command handler', () => {
         eventStore: new EventStoreInMemory()
       }
       const handlers = createCommandHandlers(deps, [rejectingCreateAggregate])
-      const commandHandler = handlers[rejectingCreateAggregate.type]
+      const commandHandler = handlers[rejectingCreateAggregate.type]!
 
       // Act
       const result = await commandHandler(createCommand)
@@ -406,12 +406,12 @@ describe('[command] command handler', () => {
 
       // First create with normal counter
       const normalHandlers = createCommandHandlers(deps, [counter])
-      const normalHandler = normalHandlers[counter.type]
+      const normalHandler = normalHandlers[counter.type]!
       await normalHandler(createCommand)
 
       // Replace with rejecting aggregate
       const testHandlers = createCommandHandlers(deps, [rejectingUpdateAggregate])
-      const testHandler = testHandlers[rejectingUpdateAggregate.type]
+      const testHandler = testHandlers[rejectingUpdateAggregate.type]!
 
       // Act - Try to update
       const result = await testHandler(incrementCommand)

--- a/tests/command/fn/apply-event.test.ts
+++ b/tests/command/fn/apply-event.test.ts
@@ -19,8 +19,16 @@ describe('[command] apply event function', () => {
     })
 
     test('should return a function when counter2 aggregate is provided', () => {
+      // Arrange
+      const deps = {
+        counterRepository: {
+          getCounter: async () => ({ type: 'active' as const, id: zeroId('counter'), count: 0 }),
+          saveCounter: async () => {}
+        }
+      }
+
       // Act
-      const applyEventFn = createApplyEventFnFactory(counter2.decider, counter2.reducer, {})()
+      const applyEventFn = createApplyEventFnFactory(counter2.decider, counter2.reducer, deps)()
 
       // Assert
       expect(applyEventFn).toBeDefined()
@@ -134,7 +142,7 @@ describe('[command] apply event function', () => {
 
     test('should handle Promise-based event decider results', async () => {
       // Arrange
-      const decider = async ({ command }) => {
+      const decider = async ({ command }: { command: CounterCommand }) => {
         return Promise.resolve({
           type: 'created' as const,
           id: command.id,
@@ -171,7 +179,7 @@ describe('[command] apply event function', () => {
     test('should pass deps to event decider function', async () => {
       // Arrange
       const testDeps = { externalService: { getValue: () => 99 } }
-      const decider = async ({ command, deps }) => {
+      const decider = async ({ command, deps }: { command: CounterCommand; deps: any }) => {
         return Promise.resolve({
           type: 'created' as const,
           id: command.id,

--- a/tests/command/fn/init-event.test.ts
+++ b/tests/command/fn/init-event.test.ts
@@ -15,8 +15,16 @@ describe('[command] init event function', () => {
     })
 
     test('should return a function when counter2 aggregate is provided', () => {
+      // Arrange
+      const deps = {
+        counterRepository: {
+          getCounter: async () => ({ type: 'active' as const, id: zeroId('counter'), count: 0 }),
+          saveCounter: async () => {}
+        }
+      }
+
       // Act
-      const initEventFn = createInitEventFnFactory(counter2.decider, counter2.reducer, {})()
+      const initEventFn = createInitEventFnFactory(counter2.decider, counter2.reducer, deps)()
 
       // Assert
       expect(initEventFn).toBeDefined()
@@ -113,7 +121,7 @@ describe('[command] init event function', () => {
 
   test('should handle Promise-based event decider results', async () => {
     // Arrange
-    const decider = async ({ command }) => {
+    const decider = async ({ command }: { command: CounterCommand }) => {
       return Promise.resolve({
         type: 'created' as const,
         id: command.id,
@@ -144,7 +152,7 @@ describe('[command] init event function', () => {
   test('should pass deps to event decider function', async () => {
     // Arrange
     const testDeps = { externalService: { getValue: () => 77 } }
-    const decider = async ({ command, deps }) => {
+    const decider = async ({ command, deps }: { command: CounterCommand; deps: any }) => {
       return Promise.resolve({
         type: 'created' as const,
         id: command.id,

--- a/tests/event/event-handler.test.ts
+++ b/tests/event/event-handler.test.ts
@@ -65,10 +65,10 @@ describe('[event] event handler', () => {
         }),
         projection: {
           created: {
-            test: () => ({
+            test: ({ event }) => ({
               type: 'test',
-              id: '123',
-              name: 'test'
+              id: event.id.value,
+              name: event.payload.name
             })
           }
         }
@@ -76,7 +76,7 @@ describe('[event] event handler', () => {
 
       const deps = {
         commandDispatcher: new MockCommandDispatcherError(),
-        ReadModelStore: new MockReadModelStoreError()
+        readModelStore: new MockReadModelStoreError()
       }
 
       const handlers = createEventHandlers(deps, [reactor])
@@ -107,10 +107,10 @@ describe('[event] event handler', () => {
         policy: () => null, // No command dispatch
         projection: {
           created: {
-            test: () => ({
+            test: ({ event }) => ({
               type: 'test',
-              id: '123',
-              name: 'test'
+              id: event.id.value,
+              name: event.payload.name
             })
           }
         }
@@ -118,7 +118,7 @@ describe('[event] event handler', () => {
 
       const deps = {
         commandDispatcher: new MockCommandDispatcherError(),
-        ReadModelStore: new MockReadModelStoreError()
+        readModelStore: new MockReadModelStoreError()
       }
 
       const handlers = createEventHandlers(deps, [reactor])
@@ -152,7 +152,7 @@ describe('[event] event handler', () => {
             test: ({ event }) => ({
               type: 'test',
               id: event.id.value,
-              name: 'test'
+              name: event.payload.name
             })
           }
         }
@@ -160,7 +160,7 @@ describe('[event] event handler', () => {
 
       const deps = {
         commandDispatcher: new MockCommandDispatcherError(),
-        ReadModelStore: new MockReadModelStoreThrows()
+        readModelStore: new MockReadModelStoreThrows()
       }
 
       const handlers = createEventHandlers(deps, [reactor])
@@ -208,7 +208,7 @@ describe('[event] event handler', () => {
             test: ({ event }) => ({
               type: 'test',
               id: event.id.value,
-              name: 'test'
+              name: event.payload.name
             })
           }
         }
@@ -216,7 +216,7 @@ describe('[event] event handler', () => {
 
       const deps = {
         commandDispatcher: new MockCommandDispatcherError(),
-        ReadModelStore: new ThrowsStringDatabase()
+        readModelStore: new ThrowsStringDatabase()
       }
 
       const handlers = createEventHandlers(deps, [reactor])


### PR DESCRIPTION
## Summary

correct type order in EventReactor and related functions

## Changes

- Updated EventReactor type definition to change the order of generic parameters
- Adjusted build methods in IEventReactorBuilder and EventReactorBuilder to reflect the new type order
- Removed unnecessary type checks in project-event.ts for improved clarity
- Enhanced tests to handle async results and ensure proper dependency injection

## Testing

- [x] Unit tests executed
- [x] Integration tests executed
