### PR TITLE
update: Simplify EventDecider function type

### DIFF
--- a/src/command/aggregate-builder.ts
+++ b/src/command/aggregate-builder.ts
@@ -1,4 +1,3 @@
-import { produce } from 'immer'
 import type {
   Aggregate,
   EventDecider,
@@ -9,17 +8,14 @@ import type {
   ReducerMap
 } from '../types/command'
 import type { Command, DomainEvent, State } from '../types/core'
-import { createAcceptsCommand, createAcceptsEvent } from './helpers/create-accepts'
+import { mapToAcceptsCommandFn, mapToAcceptsEventFn } from './mapper/map-to-accepts-fn'
+import { mapToEventDeciderFn } from './mapper/map-to-event-decider-fn'
+import { mapToReducerFn } from './mapper/map-to-reducer-fn'
 
 /**
  * Internal type representing the accumulated values in the builder
  */
-type BuilderValue<
-  S extends State,
-  C extends Command,
-  E extends DomainEvent,
-  D extends Record<string, unknown>
-> = {
+type BuilderValue<S extends State, C extends Command, E extends DomainEvent, D> = {
   type: S['id']['type']
   decider: EventDecider<S, C, E, D> | EventDecider<S, C, E, D, EventDeciderMap<S, C>>
   deciderMap?: EventDeciderMap<S, C>
@@ -41,7 +37,7 @@ export interface IAggregateBuilder<
   S extends State,
   C extends Command,
   E extends DomainEvent,
-  D extends Record<string, unknown>
+  D
 > {
   readonly _state: ST
 
@@ -78,12 +74,9 @@ export interface IAggregateBuilder<
 /**
  * Validates that all required builder values are present
  */
-function isRequiredBuilderValue<
-  S extends State,
-  C extends Command,
-  E extends DomainEvent,
-  D extends Record<string, unknown>
->(value: Partial<BuilderValue<S, C, E, D>>): value is BuilderValue<S, C, E, D> {
+function isRequiredBuilderValue<S extends State, C extends Command, E extends DomainEvent, D>(
+  value: Partial<BuilderValue<S, C, E, D>>
+): value is BuilderValue<S, C, E, D> {
   return value.type !== undefined && value.decider !== undefined && value.reducer !== undefined
 }
 
@@ -93,7 +86,7 @@ function isRequiredBuilderValue<
 function createEventDeciderFn<S extends State, C extends Command, E extends DomainEvent, D>(
   decider: EventDecider<S, C, E, D> | EventDecider<S, C, E, EventDeciderMap<S, C>>
 ): EventDeciderFn<S, C, E, D> {
-  return fromEventDecider(decider as EventDecider<S, C, E, D>)
+  return mapToEventDeciderFn(decider as EventDecider<S, C, E, D>)
 }
 
 /**
@@ -102,68 +95,7 @@ function createEventDeciderFn<S extends State, C extends Command, E extends Doma
 function createReducerFn<S extends State, E extends DomainEvent>(
   reducer: Reducer<S, E> | Reducer<S, E, ReducerMap<S, E>>
 ): ReducerFn<S, E> {
-  return fromReducer(reducer as Reducer<S, E>)
-}
-
-/**
- * Converts EventDecider object to EventDeciderFn
- */
-export function fromEventDecider<S extends State, C extends Command, E extends DomainEvent, D>(
-  deciders: EventDecider<S, C, E, D>
-): EventDeciderFn<S, C, E, D> {
-  return ({ ctx, state, command, deps }) => {
-    const deciderMap = deciders as Record<C['type'], EventDeciderFn<S, C, E, D>>
-    const decider = deciderMap[command.type as C['type']]
-    if (!decider) {
-      throw new Error(`No decider found for type: ${String(command.type)}`)
-    }
-
-    return decider({
-      ctx,
-      state,
-      command: command as Extract<C, { type: typeof command.type }>,
-      deps
-    })
-  }
-}
-
-/**
- * Converts Reducer object to ReducerFn with Immer integration
- */
-export function fromReducer<S extends State, E extends DomainEvent>(
-  reducers: Reducer<S, E>
-): ReducerFn<S, E> {
-  return ({ ctx, state, event }) => {
-    const reducer = reducers[event.type as keyof typeof reducers]
-    if (!reducer) {
-      throw new Error(`No reducer found for event type: ${String(event.type)}`)
-    }
-
-    // Holds the new typed state if returned by the reducer
-    let updatedTypedState = null
-
-    const updatedState = produce(state, draft => {
-      // The reducer mutates the draft in place. If it returns a value, store it as the typed state.
-      const res = reducer({
-        ctx,
-        state: draft,
-        event: event as Extract<E, { type: typeof event.type }>
-      })
-      if (res !== undefined) {
-        // Validate that the returned value is a proper state object
-        if (res === null || typeof res !== 'object') {
-          throw new Error(
-            `Reducer for event type "${String(event.type)}" returned invalid value: ${typeof res}. ` +
-              'Reducers must return either undefined (to use mutated draft) or a valid state object.'
-          )
-        }
-        updatedTypedState = res
-      }
-    })
-
-    // reducer mutates draft in place, so result is always the new state
-    return updatedTypedState ?? updatedState
-  }
+  return mapToReducerFn(reducer as Reducer<S, E>)
 }
 
 export class AggregateBuilder<
@@ -171,7 +103,7 @@ export class AggregateBuilder<
   S extends State,
   C extends Command,
   E extends DomainEvent,
-  D extends Record<string, unknown>
+  D
 > {
   // @ts-expect-error: phantom type to enforce state transitions
   // biome-ignore lint/correctness/noUnusedPrivateClassMembers: phantom type to enforce state transitions
@@ -235,10 +167,10 @@ export class AggregateBuilder<
     }
 
     const deciderMap: EventDeciderMap<S, C> = this.value.deciderMap ?? ({} as EventDeciderMap<S, C>)
-    const acceptsCommand = createAcceptsCommand<S, C>(deciderMap)
+    const acceptsCommand = mapToAcceptsCommandFn<S, C>(deciderMap)
 
     const reducerMap: ReducerMap<S, E> = this.value.reducerMap ?? ({} as ReducerMap<S, E>)
-    const acceptsEvent = createAcceptsEvent<S, E>(reducerMap)
+    const acceptsEvent = mapToAcceptsEventFn<S, E>(reducerMap)
 
     return {
       type: this.value.type,
@@ -250,11 +182,6 @@ export class AggregateBuilder<
   }
 }
 
-export function createAggregate<
-  S extends State,
-  C extends Command,
-  E extends DomainEvent,
-  D extends Record<string, unknown> = Record<string, unknown>
->() {
+export function createAggregate<S extends State, C extends Command, E extends DomainEvent, D>() {
   return new AggregateBuilder<'initial', S, C, E, D>({})
 }

--- a/src/command/aggregate-builder.ts
+++ b/src/command/aggregate-builder.ts
@@ -15,9 +15,9 @@ import { mapToReducerFn } from './mapper/map-to-reducer-fn'
 /**
  * Internal type representing the accumulated values in the builder
  */
-type BuilderValue<S extends State, C extends Command, E extends DomainEvent, D> = {
+type BuilderValue<S extends State, C extends Command, E extends DomainEvent> = {
   type: S['id']['type']
-  decider: EventDecider<S, C, E, D> | EventDecider<S, C, E, D, EventDeciderMap<S, C>>
+  decider: EventDecider<S, C, E> | EventDecider<S, C, E, EventDeciderMap<S, C>>
   deciderMap?: EventDeciderMap<S, C>
   reducer: Reducer<S, E> | Reducer<S, E, ReducerMap<S, E>>
   reducerMap?: ReducerMap<S, E>
@@ -36,57 +36,56 @@ export interface IAggregateBuilder<
   ST extends BuilderState,
   S extends State,
   C extends Command,
-  E extends DomainEvent,
-  D
+  E extends DomainEvent
 > {
   readonly _state: ST
 
   type<T extends string>(
-    this: IAggregateBuilder<'initial', S, C, E, D>,
+    this: IAggregateBuilder<'initial', S, C, E>,
     value: T
-  ): IAggregateBuilder<'hasType', S, C, E, D>
+  ): IAggregateBuilder<'hasType', S, C, E>
 
   decider(
-    this: IAggregateBuilder<'hasType', S, C, E, D>,
-    value: EventDecider<S, C, E, D>
-  ): IAggregateBuilder<'hasDecider', S, C, E, D>
+    this: IAggregateBuilder<'hasType', S, C, E>,
+    value: EventDecider<S, C, E>
+  ): IAggregateBuilder<'hasDecider', S, C, E>
 
   deciderWithMap(
-    this: IAggregateBuilder<'hasType', S, C, E, D>,
-    value: EventDecider<S, C, E, D>,
+    this: IAggregateBuilder<'hasType', S, C, E>,
+    value: EventDecider<S, C, E>,
     transitionMap: EventDeciderMap<S, C>
-  ): IAggregateBuilder<'hasDecider', S, C, E, D>
+  ): IAggregateBuilder<'hasDecider', S, C, E>
 
   reducer(
-    this: IAggregateBuilder<'hasDecider', S, C, E, D>,
+    this: IAggregateBuilder<'hasDecider', S, C, E>,
     value: Reducer<S, E>
-  ): IAggregateBuilder<'complete', S, C, E, D>
+  ): IAggregateBuilder<'complete', S, C, E>
 
   reducerWithMap(
-    this: IAggregateBuilder<'hasDecider', S, C, E, D>,
+    this: IAggregateBuilder<'hasDecider', S, C, E>,
     value: Reducer<S, E>,
     transitionMap: ReducerMap<S, E>
-  ): IAggregateBuilder<'complete', S, C, E, D>
+  ): IAggregateBuilder<'complete', S, C, E>
 
-  build(this: IAggregateBuilder<'complete', S, C, E, D>): Aggregate<S, C, E, D>
+  build(this: IAggregateBuilder<'complete', S, C, E>): Aggregate<S, C, E>
 }
 
 /**
  * Validates that all required builder values are present
  */
-function isRequiredBuilderValue<S extends State, C extends Command, E extends DomainEvent, D>(
-  value: Partial<BuilderValue<S, C, E, D>>
-): value is BuilderValue<S, C, E, D> {
+function isRequiredBuilderValue<S extends State, C extends Command, E extends DomainEvent, _D>(
+  value: Partial<BuilderValue<S, C, E>>
+): value is BuilderValue<S, C, E> {
   return value.type !== undefined && value.decider !== undefined && value.reducer !== undefined
 }
 
 /**
  * Helper to safely convert any decider to EventDeciderFn
  */
-function createEventDeciderFn<S extends State, C extends Command, E extends DomainEvent, D>(
-  decider: EventDecider<S, C, E, D> | EventDecider<S, C, E, EventDeciderMap<S, C>>
-): EventDeciderFn<S, C, E, D> {
-  return mapToEventDeciderFn(decider as EventDecider<S, C, E, D>)
+function createEventDeciderFn<S extends State, C extends Command, E extends DomainEvent, _D>(
+  decider: EventDecider<S, C, E> | EventDecider<S, C, E, EventDeciderMap<S, C>>
+): EventDeciderFn<S, C, E> {
+  return mapToEventDeciderFn(decider as EventDecider<S, C, E>)
 }
 
 /**
@@ -102,66 +101,65 @@ export class AggregateBuilder<
   ST extends BuilderState,
   S extends State,
   C extends Command,
-  E extends DomainEvent,
-  D
+  E extends DomainEvent
 > {
   // @ts-expect-error: phantom type to enforce state transitions
   // biome-ignore lint/correctness/noUnusedPrivateClassMembers: phantom type to enforce state transitions
   private readonly _state!: ST
 
-  constructor(private readonly value: Readonly<Partial<BuilderValue<S, C, E, D>>>) {}
+  constructor(private readonly value: Readonly<Partial<BuilderValue<S, C, E>>>) {}
 
   type(
-    this: AggregateBuilder<'initial', S, C, E, D>,
+    this: AggregateBuilder<'initial', S, C, E>,
     type: S['id']['type']
-  ): AggregateBuilder<'hasType', S, C, E, D> {
+  ): AggregateBuilder<'hasType', S, C, E> {
     return this.withValue<'hasType', { type: string }>({ type })
   }
 
   decider(
-    this: AggregateBuilder<'hasType', S, C, E, D>,
-    decider: EventDecider<S, C, E, D>
-  ): AggregateBuilder<'hasDecider', S, C, E, D> {
-    return this.withValue<'hasDecider', { decider: EventDecider<S, C, E, D> }>({ decider })
+    this: AggregateBuilder<'hasType', S, C, E>,
+    decider: EventDecider<S, C, E>
+  ): AggregateBuilder<'hasDecider', S, C, E> {
+    return this.withValue<'hasDecider', { decider: EventDecider<S, C, E> }>({ decider })
   }
 
   deciderWithMap<DM extends EventDeciderMap<S, C>>(
-    this: AggregateBuilder<'hasType', S, C, E, D>,
-    decider: EventDecider<S, C, E, D, DM>,
+    this: AggregateBuilder<'hasType', S, C, E>,
+    decider: EventDecider<S, C, E, DM>,
     deciderMap: DM
-  ): AggregateBuilder<'hasDecider', S, C, E, D> {
-    return this.withValue<'hasDecider', { decider: EventDecider<S, C, E, D, DM>; deciderMap: DM }>({
+  ): AggregateBuilder<'hasDecider', S, C, E> {
+    return this.withValue<'hasDecider', { decider: EventDecider<S, C, E, DM>; deciderMap: DM }>({
       decider,
       deciderMap
     })
   }
 
   reducer(
-    this: AggregateBuilder<'hasDecider', S, C, E, D>,
+    this: AggregateBuilder<'hasDecider', S, C, E>,
     reducer: Reducer<S, E>
-  ): AggregateBuilder<'complete', S, C, E, D> {
+  ): AggregateBuilder<'complete', S, C, E> {
     return this.withValue<'complete', { reducer: Reducer<S, E> }>({ reducer })
   }
 
   reducerWithMap<RM extends ReducerMap<S, E>>(
-    this: AggregateBuilder<'hasDecider', S, C, E, D>,
+    this: AggregateBuilder<'hasDecider', S, C, E>,
     reducer: Reducer<S, E, RM>,
     reducerMap: RM
-  ): AggregateBuilder<'complete', S, C, E, D> {
+  ): AggregateBuilder<'complete', S, C, E> {
     return this.withValue<'complete', { reducer: Reducer<S, E, RM>; reducerMap: RM }>({
       reducer,
       reducerMap
     })
   }
 
-  private withValue<NS extends BuilderState, T extends Partial<BuilderValue<S, C, E, D>>>(
+  private withValue<NS extends BuilderState, T extends Partial<BuilderValue<S, C, E>>>(
     updates: T
-  ): AggregateBuilder<NS, S, C, E, D> {
+  ): AggregateBuilder<NS, S, C, E> {
     const newValue = { ...this.value, ...updates }
-    return new AggregateBuilder<NS, S, C, E, D>(newValue)
+    return new AggregateBuilder<NS, S, C, E>(newValue)
   }
 
-  build(this: AggregateBuilder<'complete', S, C, E, D>): Aggregate<S, C, E, D> {
+  build(this: AggregateBuilder<'complete', S, C, E>): Aggregate<S, C, E> {
     if (!isRequiredBuilderValue(this.value)) {
       throw new Error('Aggregate is not ready to build. Missing required properties.')
     }
@@ -176,12 +174,12 @@ export class AggregateBuilder<
       type: this.value.type,
       acceptsCommand,
       acceptsEvent,
-      decider: createEventDeciderFn(this.value.decider as EventDecider<S, C, E, D>),
+      decider: createEventDeciderFn(this.value.decider as EventDecider<S, C, E>),
       reducer: createReducerFn(this.value.reducer)
     }
   }
 }
 
-export function createAggregate<S extends State, C extends Command, E extends DomainEvent, D>() {
-  return new AggregateBuilder<'initial', S, C, E, D>({})
+export function createAggregate<S extends State, C extends Command, E extends DomainEvent, _D>() {
+  return new AggregateBuilder<'initial', S, C, E>({})
 }

--- a/src/command/command-handler.ts
+++ b/src/command/command-handler.ts
@@ -15,20 +15,12 @@ function createCommandHandlerFactory<
   S extends State,
   C extends Command,
   E extends DomainEvent,
-  D extends CommandHandlerDeps & Record<string, unknown>
->(aggregate: Aggregate<S, C, E, D>): CommandHandlerFactory<D> {
+  D extends CommandHandlerDeps
+>(aggregate: Aggregate<S, C, E>): CommandHandlerFactory<D> {
   return (deps: D) => {
     const replayFn = createReplayEventFnFactory<S, E>(aggregate.reducer)(deps.eventStore)
-    const initFn = createInitEventFnFactory<S, C, E, D>(
-      aggregate.decider,
-      aggregate.reducer,
-      deps
-    )()
-    const applyFn = createApplyEventFnFactory<S, C, E, D>(
-      aggregate.decider,
-      aggregate.reducer,
-      deps
-    )()
+    const initFn = createInitEventFnFactory<S, C, E>(aggregate.decider, aggregate.reducer)()
+    const applyFn = createApplyEventFnFactory<S, C, E>(aggregate.decider, aggregate.reducer)()
     const saveFn = createSaveEventFnFactory<S, E>()(deps.eventStore)
 
     // Handles aggregate creation or update based on the incoming command

--- a/src/command/fn/apply-event.ts
+++ b/src/command/fn/apply-event.ts
@@ -22,13 +22,8 @@ type ApplyEventFn<S extends State, C extends Command, E extends DomainEvent> = (
 export function createApplyEventFnFactory<
   S extends State,
   C extends Command,
-  E extends DomainEvent,
-  D extends Record<string, unknown> = Record<string, unknown>
->(
-  eventDecider: EventDeciderFn<S, C, E, D>,
-  reducer: ReducerFn<S, E>,
-  deps: D
-): () => ApplyEventFn<S, C, E> {
+  E extends DomainEvent
+>(eventDecider: EventDeciderFn<S, C, E>, reducer: ReducerFn<S, E>): () => ApplyEventFn<S, C, E> {
   return () => {
     return async (state: ExtendedState<S>, command: C) => {
       const timestamp = new Date()
@@ -36,7 +31,7 @@ export function createApplyEventFnFactory<
       const deciderCtx: EventDeciderContext = {
         timestamp
       }
-      const eventRes = toResult(() => eventDecider({ ctx: deciderCtx, state, command, deps }))
+      const eventRes = toResult(() => eventDecider({ ctx: deciderCtx, state, command }))
       if (!eventRes.ok) {
         return err({
           code: 'EVENT_DECIDER_ERROR',

--- a/src/command/fn/init-event.ts
+++ b/src/command/fn/init-event.ts
@@ -18,15 +18,9 @@ type InitEventFn<S extends State, C extends Command, E extends DomainEvent> = (
   command: C
 ) => Promise<Result<{ state: ExtendedState<S>; event: ExtendedDomainEvent<E> }, AppError>>
 
-export function createInitEventFnFactory<
-  S extends State,
-  C extends Command,
-  E extends DomainEvent,
-  D extends Record<string, unknown> = Record<string, unknown>
->(
-  eventDecider: EventDeciderFn<S, C, E, D>,
-  reducer: ReducerFn<S, E>,
-  deps: D
+export function createInitEventFnFactory<S extends State, C extends Command, E extends DomainEvent>(
+  eventDecider: EventDeciderFn<S, C, E>,
+  reducer: ReducerFn<S, E>
 ): () => InitEventFn<S, C, E> {
   return () => {
     return async (command: C) => {
@@ -42,7 +36,7 @@ export function createInitEventFnFactory<
         timestamp: new Date()
       }
       const eventRes = toResult(() =>
-        eventDecider({ ctx: deciderCtx, state: provisionalState, command, deps })
+        eventDecider({ ctx: deciderCtx, state: provisionalState, command })
       )
       if (!eventRes.ok) {
         return err({

--- a/src/command/mapper/map-to-accepts-fn.ts
+++ b/src/command/mapper/map-to-accepts-fn.ts
@@ -21,7 +21,7 @@ const isMapVoid = <T extends { type: string }>(map: Record<string, string[]>, ke
   return map[key.type] !== undefined && map[key.type] !== null && map[key.type]?.length === 0
 }
 
-export const createAcceptsCommand = <S extends State, C extends Command>(
+export const mapToAcceptsCommandFn = <S extends State, C extends Command>(
   map: EventDeciderMap<S, C>
 ): AcceptsCommandFn<S, C> => {
   return (state: S, command: C, eventType: ApplyEventType) => {
@@ -32,7 +32,7 @@ export const createAcceptsCommand = <S extends State, C extends Command>(
   }
 }
 
-export const createAcceptsEvent = <S extends State, E extends DomainEvent>(
+export const mapToAcceptsEventFn = <S extends State, E extends DomainEvent>(
   map: ReducerMap<S, E>
 ): AcceptsEventFn<S, E> => {
   return (state: S, event: E, eventType: ApplyEventType) => {

--- a/src/command/mapper/map-to-event-decider-fn.ts
+++ b/src/command/mapper/map-to-event-decider-fn.ts
@@ -1,11 +1,11 @@
 import type { EventDecider, EventDeciderFn } from '../../types/command'
 import type { Command, DomainEvent, State } from '../../types/core'
 
-export function mapToEventDeciderFn<S extends State, C extends Command, E extends DomainEvent, D>(
-  deciders: EventDecider<S, C, E, D>
-): EventDeciderFn<S, C, E, D> {
-  return ({ ctx, state, command, deps }) => {
-    const deciderMap = deciders as Record<C['type'], EventDeciderFn<S, C, E, D>>
+export function mapToEventDeciderFn<S extends State, C extends Command, E extends DomainEvent, _D>(
+  deciders: EventDecider<S, C, E>
+): EventDeciderFn<S, C, E> {
+  return ({ ctx, state, command }) => {
+    const deciderMap = deciders as Record<C['type'], EventDeciderFn<S, C, E>>
     const decider = deciderMap[command.type as C['type']]
     if (!decider) {
       throw new Error(`No decider found for type: ${String(command.type)}`)
@@ -14,8 +14,7 @@ export function mapToEventDeciderFn<S extends State, C extends Command, E extend
     return decider({
       ctx,
       state,
-      command: command as Extract<C, { type: typeof command.type }>,
-      deps
+      command: command as Extract<C, { type: typeof command.type }>
     })
   }
 }

--- a/src/command/mapper/map-to-event-decider-fn.ts
+++ b/src/command/mapper/map-to-event-decider-fn.ts
@@ -1,0 +1,21 @@
+import type { EventDecider, EventDeciderFn } from '../../types/command'
+import type { Command, DomainEvent, State } from '../../types/core'
+
+export function mapToEventDeciderFn<S extends State, C extends Command, E extends DomainEvent, D>(
+  deciders: EventDecider<S, C, E, D>
+): EventDeciderFn<S, C, E, D> {
+  return ({ ctx, state, command, deps }) => {
+    const deciderMap = deciders as Record<C['type'], EventDeciderFn<S, C, E, D>>
+    const decider = deciderMap[command.type as C['type']]
+    if (!decider) {
+      throw new Error(`No decider found for type: ${String(command.type)}`)
+    }
+
+    return decider({
+      ctx,
+      state,
+      command: command as Extract<C, { type: typeof command.type }>,
+      deps
+    })
+  }
+}

--- a/src/command/mapper/map-to-reducer-fn.ts
+++ b/src/command/mapper/map-to-reducer-fn.ts
@@ -1,0 +1,39 @@
+import { produce } from 'immer'
+import type { Reducer, ReducerFn } from '../../types/command'
+import type { DomainEvent, State } from '../../types/core'
+
+export function mapToReducerFn<S extends State, E extends DomainEvent>(
+  reducers: Reducer<S, E>
+): ReducerFn<S, E> {
+  return ({ ctx, state, event }) => {
+    const reducer = reducers[event.type as keyof typeof reducers]
+    if (!reducer) {
+      throw new Error(`No reducer found for event type: ${String(event.type)}`)
+    }
+
+    // Holds the new typed state if returned by the reducer
+    let updatedTypedState = null
+
+    const updatedState = produce(state, draft => {
+      // The reducer mutates the draft in place. If it returns a value, store it as the typed state.
+      const res = reducer({
+        ctx,
+        state: draft,
+        event: event as Extract<E, { type: typeof event.type }>
+      })
+      if (res !== undefined) {
+        // Validate that the returned value is a proper state object
+        if (res === null || typeof res !== 'object') {
+          throw new Error(
+            `Reducer for event type "${String(event.type)}" returned invalid value: ${typeof res}. ` +
+              'Reducers must return either undefined (to use mutated draft) or a valid state object.'
+          )
+        }
+        updatedTypedState = res
+      }
+    })
+
+    // reducer mutates draft in place, so result is always the new state
+    return updatedTypedState ?? updatedState
+  }
+}

--- a/src/types/command/aggregate.ts
+++ b/src/types/command/aggregate.ts
@@ -3,13 +3,13 @@ import type { AcceptsCommandFn, AcceptsEventFn } from './accepts-fn'
 import type { EventDeciderFn } from './event-decider-fn'
 import type { ReducerFn } from './reducer-fn'
 
-export type Aggregate<S extends State, C extends Command, E extends DomainEvent, D> = {
+export type Aggregate<S extends State, C extends Command, E extends DomainEvent> = {
   type: S['id']['type']
   acceptsCommand: AcceptsCommandFn<S, C>
   acceptsEvent: AcceptsEventFn<S, E>
-  decider: EventDeciderFn<S, C, E, D>
+  decider: EventDeciderFn<S, C, E>
   reducer: ReducerFn<S, E>
 }
 
 // biome-ignore lint: To enable a generic Aggregate type for utility and type inference purposes.
-export type AnyAggregate = Aggregate<any, any, any, any>
+export type AnyAggregate = Aggregate<any, any, any>

--- a/src/types/command/event-decider-fn.ts
+++ b/src/types/command/event-decider-fn.ts
@@ -8,13 +8,12 @@ export type EventDeciderMap<S extends State, C extends Command> = {
   [K in C['type']]: S['type'][]
 }
 
-export type EventDeciderParams<S extends State, C extends Command, D> = {
+export type EventDeciderParams<S extends State, C extends Command> = {
   ctx: EventDeciderContext
   state: S
   command: C
-  deps: D
 }
 
-export type EventDeciderFn<S extends State, C extends Command, E extends DomainEvent, D> = (
-  params: EventDeciderParams<S, C, D>
+export type EventDeciderFn<S extends State, C extends Command, E extends DomainEvent> = (
+  params: EventDeciderParams<S, C>
 ) => E | Promise<E>

--- a/src/types/command/event-decider.ts
+++ b/src/types/command/event-decider.ts
@@ -5,14 +5,13 @@ export type EventDecider<
   S extends State,
   C extends Command,
   E extends DomainEvent,
-  D = Record<string, unknown>,
   DM extends EventDeciderMap<S, C> = never
 > = [DM] extends [never]
   ? {
-      [K in C['type']]: EventDeciderFn<S, Extract<C, { type: K }>, E, D>
+      [K in C['type']]: EventDeciderFn<S, Extract<C, { type: K }>, E>
     }
   : {
       [K in keyof DM]: DM[K][number] extends never
-        ? EventDeciderFn<never, Extract<C, { type: K }>, E, D>
-        : EventDeciderFn<Extract<S, { type: DM[K][number] }>, Extract<C, { type: K }>, E, D>
+        ? EventDeciderFn<never, Extract<C, { type: K }>, E>
+        : EventDeciderFn<Extract<S, { type: DM[K][number] }>, Extract<C, { type: K }>, E>
     }

--- a/tests/command/fn/apply-event.test.ts
+++ b/tests/command/fn/apply-event.test.ts
@@ -175,42 +175,5 @@ describe('[command] apply event function', () => {
         expect(res.value.state.count).toBe(42)
       }
     })
-
-    test('should pass deps to event decider function', async () => {
-      // Arrange
-      const testDeps = { externalService: { getValue: () => 99 } }
-      const decider = async ({ command, deps }: { command: CounterCommand; deps: any }) => {
-        return Promise.resolve({
-          type: 'created' as const,
-          id: command.id,
-          payload: { count: deps.externalService.getValue() }
-        })
-      }
-      const applyEventFn = createApplyEventFnFactory(decider, counter.reducer, testDeps)()
-
-      const id = zeroId('counter')
-      const state: ExtendedState<CounterState> = {
-        type: 'active',
-        id,
-        count: 0,
-        version: 0
-      }
-      const command: CounterCommand = {
-        type: 'create',
-        id,
-        payload: { count: 0 }
-      }
-
-      // Act
-      const res = await applyEventFn(state, command)
-
-      // Assert
-      expect(res).toBeDefined()
-      expect(res.ok).toBe(true)
-      if (res.ok) {
-        expect(res.value.event.payload).toEqual({ count: 99 })
-        expect(res.value.state.count).toBe(99)
-      }
-    })
   })
 })

--- a/tests/command/fn/init-event.test.ts
+++ b/tests/command/fn/init-event.test.ts
@@ -148,35 +148,4 @@ describe('[command] init event function', () => {
       expect(res.value.state.count).toBe(55)
     }
   })
-
-  test('should pass deps to event decider function', async () => {
-    // Arrange
-    const testDeps = { externalService: { getValue: () => 77 } }
-    const decider = async ({ command, deps }: { command: CounterCommand; deps: any }) => {
-      return Promise.resolve({
-        type: 'created' as const,
-        id: command.id,
-        payload: { count: deps.externalService.getValue() }
-      })
-    }
-    const initEventFn = createInitEventFnFactory(decider, counter.reducer, testDeps)()
-
-    const id = zeroId('counter')
-    const command: CounterCommand = {
-      type: 'create',
-      id,
-      payload: { count: 0 }
-    }
-
-    // Act
-    const res = await initEventFn(command)
-
-    // Assert
-    expect(res).toBeDefined()
-    expect(res.ok).toBe(true)
-    if (res.ok) {
-      expect(res.value.event.payload.count).toEqual(77)
-      expect(res.value.state.count).toBe(77)
-    }
-  })
 })

--- a/tests/command/helpers/create-accepts.test.ts
+++ b/tests/command/helpers/create-accepts.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 import { zeroId } from '../../../src'
 import {
-  createAcceptsCommand,
-  createAcceptsEvent
-} from '../../../src/command/helpers/create-accepts'
+  mapToAcceptsCommandFn,
+  mapToAcceptsEventFn
+} from '../../../src/command/mapper/map-to-accepts-fn'
 import type { EventDeciderMap, ReducerMap } from '../../../src/types/command'
 import type { AggregateId } from '../../../src/types/core'
 
@@ -25,10 +25,10 @@ type TestEvent =
   | { type: 'deactivated'; id: AggregateId }
 
 describe('[command] create accepts function', () => {
-  describe('createAcceptsCommandFn', () => {
+  describe('mapToAcceptsCommandFnFn', () => {
     test('accepts all command and state combinations when empty map is provided', () => {
       const emptyMap = {} as EventDeciderMap<TestState, TestCommand>
-      const acceptsCommand = createAcceptsCommand(emptyMap)
+      const acceptsCommand = mapToAcceptsCommandFn(emptyMap)
 
       const id = zeroId('test')
       const initialState: TestState = { type: 'initial', id }
@@ -53,7 +53,7 @@ describe('[command] create accepts function', () => {
         deactivate: ['active'] // deactivate command only accepted in active state
       }
 
-      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const acceptsCommand = mapToAcceptsCommandFn(deciderMap)
       const id = zeroId('test')
       const createCommand: TestCommand = { type: 'create', id, payload: { value: 5 } }
       const anyState: TestState = { type: 'active', id, value: 10 }
@@ -70,7 +70,7 @@ describe('[command] create accepts function', () => {
         deactivate: ['active']
       }
 
-      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const acceptsCommand = mapToAcceptsCommandFn(deciderMap)
       const id = zeroId('test')
       const updateCommand: TestCommand = { type: 'update', id, payload: { value: 15 } }
       const anyState: TestState = { type: 'active', id, value: 10 }
@@ -87,7 +87,7 @@ describe('[command] create accepts function', () => {
         deactivate: ['active']
       }
 
-      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const acceptsCommand = mapToAcceptsCommandFn(deciderMap)
       const id = zeroId('test')
       const activeState: TestState = { type: 'active', id, value: 10 }
       const initialState: TestState = { type: 'initial', id }
@@ -108,7 +108,7 @@ describe('[command] create accepts function', () => {
         deactivate: ['active']
       }
 
-      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const acceptsCommand = mapToAcceptsCommandFn(deciderMap)
       const id = zeroId('test')
       const activeState: TestState = { type: 'active', id, value: 10 }
       const initialState: TestState = { type: 'initial', id }
@@ -129,7 +129,7 @@ describe('[command] create accepts function', () => {
         deactivate: ['active']
       }
 
-      const acceptsCommand = createAcceptsCommand(deciderMap)
+      const acceptsCommand = mapToAcceptsCommandFn(deciderMap)
       const id = zeroId('test')
       const unknownCommand = { type: 'unknown', id } as unknown as TestCommand
       const activeState: TestState = { type: 'active', id, value: 10 }
@@ -139,10 +139,10 @@ describe('[command] create accepts function', () => {
     })
   })
 
-  describe('createAcceptsEventFn', () => {
+  describe('mapToAcceptsEventFnFn', () => {
     test('accepts all event and state combinations when empty map is provided', () => {
       const emptyMap = {} as ReducerMap<TestState, TestEvent>
-      const acceptsEvent = createAcceptsEvent(emptyMap)
+      const acceptsEvent = mapToAcceptsEventFn(emptyMap)
 
       const id = zeroId('test')
       const initialState: TestState = { type: 'initial', id }
@@ -167,7 +167,7 @@ describe('[command] create accepts function', () => {
         deactivated: ['active'] // deactivated event only applies to active state
       }
 
-      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const acceptsEvent = mapToAcceptsEventFn(reducerMap)
       const id = zeroId('test')
       const createdEvent: TestEvent = { type: 'created', id, payload: { value: 5 } }
       const anyState: TestState = { type: 'active', id, value: 10 }
@@ -184,7 +184,7 @@ describe('[command] create accepts function', () => {
         deactivated: ['active']
       }
 
-      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const acceptsEvent = mapToAcceptsEventFn(reducerMap)
       const id = zeroId('test')
       const updatedEvent: TestEvent = { type: 'updated', id, payload: { value: 15 } }
       const anyState: TestState = { type: 'active', id, value: 10 }
@@ -201,7 +201,7 @@ describe('[command] create accepts function', () => {
         deactivated: ['active']
       }
 
-      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const acceptsEvent = mapToAcceptsEventFn(reducerMap)
       const id = zeroId('test')
       const activeState: TestState = { type: 'active', id, value: 10 }
       const initialState: TestState = { type: 'initial', id }
@@ -222,7 +222,7 @@ describe('[command] create accepts function', () => {
         deactivated: ['active']
       }
 
-      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const acceptsEvent = mapToAcceptsEventFn(reducerMap)
       const id = zeroId('test')
       const activeState: TestState = { type: 'active', id, value: 10 }
       const initialState: TestState = { type: 'initial', id }
@@ -243,7 +243,7 @@ describe('[command] create accepts function', () => {
         deactivated: ['active']
       }
 
-      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const acceptsEvent = mapToAcceptsEventFn(reducerMap)
       const id = zeroId('test')
       const activatedEvent: TestEvent = { type: 'activated', id }
       const deactivatedEvent: TestEvent = { type: 'deactivated', id }
@@ -271,7 +271,7 @@ describe('[command] create accepts function', () => {
         deactivated: ['active']
       }
 
-      const acceptsEvent = createAcceptsEvent(reducerMap)
+      const acceptsEvent = mapToAcceptsEventFn(reducerMap)
       const id = zeroId('test')
       const unknownEvent = { type: 'unknown', id } as unknown as TestEvent
       const activeState: TestState = { type: 'active', id, value: 10 }
@@ -289,7 +289,7 @@ describe('[command] create accepts function', () => {
         deactivated: ['active'] // Add required property
       } as unknown as ReducerMap<TestState, TestEvent>
 
-      const acceptsEvent = createAcceptsEvent(mapWithNull)
+      const acceptsEvent = mapToAcceptsEventFn(mapWithNull)
       const id = zeroId('test')
       const activeState: TestState = { type: 'active', id, value: 10 }
 


### PR DESCRIPTION
## Summary

- Simplify the eventDecider type and change it to a pure function.
- Move the mapper function to a separate file.

## Changes

### refactor: simplify type definitions in command handling
    
- Removed unused generic parameters from Aggregate and EventDecider types
- Updated function signatures in command handler and event functions for improved clarity
- Enhanced type safety by reducing unnecessary complexity in type definitions
- Streamlined the aggregate builder implementation to focus on essential types

### refactor: update aggregate builder and introduce mapping functions
    
- Removed unused imports and refactored type definitions in aggregate-builder.ts
- Introduced new mapping functions for command and event handling in separate files
- Enhanced the createEventDeciderFn and createReducerFn functions to use the new mapping functions
- Improved type safety and clarity in the aggregate builder implementation

## Testing

- [x] Unit tests executed

## Related Issues

## Notes
<!-- Any additional information or context -->
