### PR TITLE
fix: enhance prefetch-read-model to create placeholders for missing models

### DIFF
--- a/src/event/event-handler.ts
+++ b/src/event/event-handler.ts
@@ -23,10 +23,10 @@ function createEventHandlerFactory<D extends EventHandlerDeps>(
     return async (event: ExtendedDomainEvent<DomainEvent>) => {
       // MARK: projection workflow
 
-      const modelDict = await prefetchReadModels(event)
-      if (!modelDict.ok) return modelDict
+      const models = await prefetchReadModels(event)
+      if (!models.ok) return models
 
-      const projected = await projection(event, modelDict.value)
+      const projected = await projection(event, models.value)
       if (!projected.ok) return projected
 
       const saved = await saveReadModel(projected.value)

--- a/src/event/mapper/map-to-projection-fn.ts
+++ b/src/event/mapper/map-to-projection-fn.ts
@@ -31,6 +31,7 @@ export function mapProjectionToFn<
         readModel: draft
       }
 
+      // biome-ignore lint/suspicious/noExplicitAny: "result is used to store the result of the projection function"
       const result = projectionFn(projectionParams as any)
       if (result === undefined) {
         // Projection mutated the draft in-place → immer will return the new read model automatically.

--- a/src/fake/event-reactor-fixture.ts
+++ b/src/fake/event-reactor-fixture.ts
@@ -84,14 +84,14 @@ class ReactorTestFixture<E extends DomainEvent, C extends Command, RM extends Re
     }
 
     // 2. apply projection to each readModel
-    const projectionFn = mapProjectionToFn(this.reactor.projection as any)
+    const projectionFn = mapProjectionToFn(this.reactor.projection)
     const updatedDict: Record<string, ReadModel> = {}
 
     for (const [key, model] of Object.entries(modelDict)) {
       const updatedModel = projectionFn({
         ctx: { timestamp: event.timestamp },
         event: event as unknown as E,
-        readModel: model as any
+        readModel: model as RM
       })
       updatedDict[key] = updatedModel
     }
@@ -115,7 +115,7 @@ class ReactorTestFixture<E extends DomainEvent, C extends Command, RM extends Re
           const newModel = projectionFn({
             ctx: { timestamp: event.timestamp },
             event: event as unknown as E,
-            readModel: placeholderModel as any
+            readModel: placeholderModel as RM
           })
 
           if (newModel && newModel !== placeholderModel) {

--- a/tests/event/fn/prefetch-read-model.test.ts
+++ b/tests/event/fn/prefetch-read-model.test.ts
@@ -89,7 +89,7 @@ describe('[event] prefetch-read-model', () => {
       }
     })
 
-    test('returns error when model with invalid type not found', async () => {
+    test('creates placeholder when model with invalid type not found', async () => {
       // Arrange
       const store = new ReadModelStoreInMemory()
 
@@ -110,9 +110,14 @@ describe('[event] prefetch-read-model', () => {
       const result = await prefetchFn(event)
 
       // Assert
-      expect(result.ok).toBe(false)
-      if (!result.ok) {
-        expect(result.error.code).toBe('READ_MODEL_NOT_FOUND')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(Object.keys(result.value)).toHaveLength(1)
+        const placeholderKey = `invalid_type${event.id.value}`
+        expect(result.value[placeholderKey]).toEqual({
+          type: 'invalid_type',
+          id: event.id.value
+        })
       }
     })
 
@@ -152,7 +157,7 @@ describe('[event] prefetch-read-model', () => {
       }
     })
 
-    test('returns error when model not found by id', async () => {
+    test('creates placeholder when model not found by id', async () => {
       // Arrange
       const store = new ReadModelStoreInMemory()
 
@@ -173,9 +178,14 @@ describe('[event] prefetch-read-model', () => {
       const result = await prefetchFn(event)
 
       // Assert
-      expect(result.ok).toBe(false)
-      if (!result.ok) {
-        expect(result.error.code).toBe('READ_MODEL_NOT_FOUND')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(Object.keys(result.value)).toHaveLength(1)
+        const placeholderKey = `counter${event.id.value}`
+        expect(result.value[placeholderKey]).toEqual({
+          type: 'counter',
+          id: event.id.value
+        })
       }
     })
 


### PR DESCRIPTION
## Summary

enhance prefetch-read-model to create placeholders for missing models

## Changes

- Updated prefetch-read-model to return placeholders when models are not found
- Refactored event-handler to use consistent variable naming for read models
- Improved type handling in map-to-projection-fn and event-reactor-fixture
- Adjusted tests to verify placeholder creation instead of error on missing models

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests executed
- [x] Integration tests executed
