### PR TITLE
refactor: rename storage to records in ReadModelStoreInMemory

### DIFF
--- a/src/adapter/read-model-store-in-memory.ts
+++ b/src/adapter/read-model-store-in-memory.ts
@@ -4,13 +4,13 @@ import type { ReadModel } from '../types/core'
 type ModelOfType<M extends ReadModel, T extends M['type']> = M extends { type: T } ? M : never
 
 export class ReadModelStoreInMemory<M extends ReadModel = ReadModel> implements ReadModelStore<M> {
-  storage: Record<string, Record<string, M>> = {}
+  records: Record<string, Record<string, M>> = {}
 
   async findMany<T extends M['type']>(
     type: T,
     options: QueryOption<ModelOfType<M, T>>
   ): Promise<ModelOfType<M, T>[]> {
-    const dataMap = this.storage[type as string]
+    const dataMap = this.records[type as string]
     if (!dataMap) return []
 
     let items = Object.values(dataMap) as ModelOfType<M, T>[]
@@ -92,7 +92,7 @@ export class ReadModelStoreInMemory<M extends ReadModel = ReadModel> implements 
   }
 
   async findById<T extends M['type']>(type: T, id: string): Promise<ModelOfType<M, T> | null> {
-    const typeStorage = this.storage[type as string]
+    const typeStorage = this.records[type as string]
     if (!typeStorage) return null
 
     const readModel = typeStorage[id]
@@ -102,19 +102,19 @@ export class ReadModelStoreInMemory<M extends ReadModel = ReadModel> implements 
   }
 
   async save(model: M): Promise<void> {
-    const typeStorage = this.storage[model.type] || {}
+    const typeStorage = this.records[model.type] || {}
     typeStorage[model.id] = model
-    this.storage[model.type] = typeStorage
+    this.records[model.type] = typeStorage
   }
 
   async delete(model: M): Promise<void> {
-    const typeStorage = this.storage[model.type]
+    const typeStorage = this.records[model.type]
     if (typeStorage) {
       delete typeStorage[model.id]
     }
   }
 
   clear(): void {
-    this.storage = {}
+    this.records = {}
   }
 }

--- a/src/fake/fake-handler.ts
+++ b/src/fake/fake-handler.ts
@@ -33,7 +33,7 @@ const defaultConfig = {
 
 export class FakeHandler {
   readonly eventStore: EventStoreInMemory
-  readonly readDatabase: ReadModelStoreInMemory
+  readonly readModelStore: ReadModelStoreInMemory
   readonly commandDispatcher: CommandDispatcherMock
   readonly config: typeof defaultConfig
 
@@ -48,7 +48,7 @@ export class FakeHandler {
     querySources = [],
     queryMiddleware = [],
     eventStore = new EventStoreInMemory(),
-    readDatabase = new ReadModelStoreInMemory(),
+    readModelStore = new ReadModelStoreInMemory(),
     commandDispatcher = new CommandDispatcherMock(),
     config = {}
   }: {
@@ -58,12 +58,12 @@ export class FakeHandler {
     querySources?: AnyQuerySource[]
     queryMiddleware?: QueryHandlerMiddleware[]
     eventStore?: EventStoreInMemory
-    readDatabase?: ReadModelStoreInMemory
+    readModelStore?: ReadModelStoreInMemory
     commandDispatcher?: CommandDispatcherMock
     config?: Partial<typeof defaultConfig>
   }) {
     this.eventStore = eventStore
-    this.readDatabase = readDatabase
+    this.readModelStore = readModelStore
     this.commandDispatcher = commandDispatcher
 
     this.commandBus = createCommandBus({
@@ -73,12 +73,12 @@ export class FakeHandler {
     })
 
     this.eventBus = createEventBus({
-      deps: { commandDispatcher: this.commandDispatcher, readModelStore: this.readDatabase },
+      deps: { commandDispatcher: this.commandDispatcher, readModelStore: this.readModelStore },
       reactors: reactors ?? []
     })
 
     this.queryBus = createQueryBus({
-      deps: { readModelStore: this.readDatabase },
+      deps: { readModelStore: this.readModelStore },
       querySources: querySources ?? [],
       middleware: queryMiddleware ?? []
     })
@@ -144,13 +144,22 @@ export class FakeHandler {
   }
 
   setReadDatabase(storage: Record<string, Record<string, ReadModel>>) {
-    this.readDatabase.storage = storage
+    this.readModelStore.records = storage
   }
 
   reset() {
     this.eventStore.events = []
     this.eventStore.snapshots = []
-    this.readDatabase.storage = {}
+    this.readModelStore.records = {}
     this.commandDispatcher.reset()
+  }
+
+  log() {
+    console.log('-- eventStore.events --')
+    console.log(this.eventStore.events)
+    console.log()
+    console.log('-- readModelStore.records --')
+    console.log(this.readModelStore.records)
+    console.log()
   }
 }

--- a/tests/adapter/read-model-store-in-memory.test.ts
+++ b/tests/adapter/read-model-store-in-memory.test.ts
@@ -301,11 +301,11 @@ describe('[adapter] read model store in memory', () => {
           await store.save(product)
         }
 
-        expect(Object.keys(store.storage)).toHaveLength(2)
+        expect(Object.keys(store.records)).toHaveLength(2)
 
         store.clear()
 
-        expect(store.storage).toEqual({})
+        expect(store.records).toEqual({})
       })
     })
   })


### PR DESCRIPTION
## Summary

Rename storage to records in ReadModelStoreInMemory

## Changes

- Renamed 'storage' property to 'records' in ReadModelStoreInMemory class
- Updated all references to 'storage' in the class methods and related tests
- Adjusted variable names in ReactorTestFixture and FakeHandler for consistency

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests executed
- [x] Integration tests executed
