### PR TITLE
refactor: simplify state and read model handling in mapping functions

### DIFF
--- a/src/command/mapper/map-to-reducer-fn.ts
+++ b/src/command/mapper/map-to-reducer-fn.ts
@@ -11,9 +11,6 @@ export function mapToReducerFn<S extends State, E extends DomainEvent>(
       throw new Error(`No reducer found for event type: "${String(event.type)}"`)
     }
 
-    // If the reducer returns a completely new state object, store it here.
-    let replacementState: S | null = null
-
     const producedState = produce(state, draft => {
       const params = {
         ctx,
@@ -34,10 +31,11 @@ export function mapToReducerFn<S extends State, E extends DomainEvent>(
         )
       }
 
-      replacementState = result
+      // biome-ignore lint/suspicious/noExplicitAny: 'result is used to store the result of the reducer function'
+      return result as any
     })
 
     // If the reducer returned a new state object, use it; otherwise, use the produced draft result.
-    return replacementState ?? producedState
+    return producedState
   }
 }


### PR DESCRIPTION
## Summary

Simplify state and read model handling in mapping functions

## Changes

- Removed unnecessary replacement state and read model variables in mapToReducerFn and mapProjectionToFn
- Updated return logic to directly use produced state and read model
- Improved type handling for results in both mapping functions

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests executed
- [x] Integration tests executed
