### PR TITLE
refactor: enhance prefetch-read-model and projection type handling

### DIFF
--- a/src/event/fn/prefetch-read-model.ts
+++ b/src/event/fn/prefetch-read-model.ts
@@ -1,7 +1,7 @@
 import { v4 } from 'uuid'
 import type { FilterCondition, ReadModelStore } from '../../types/adapter'
 import type { DomainEvent, ReadModel } from '../../types/core'
-import type { ProjectionMap, ProjectionMapValue } from '../../types/event'
+import type { ProjectionMap } from '../../types/event'
 import type { AppError, AsyncResult } from '../../types/utils'
 import { err, ok, toAsyncResult } from '../../utils/result'
 import { validateEvent } from '../helpers/validate-domain-event'
@@ -20,11 +20,8 @@ export function createPrefetchReadModel<E extends DomainEvent, RM extends ReadMo
 
       const dict: Record<string, ReadModel> = {}
 
-      const modelFetchList = map[event.type as keyof typeof map]
-      for (const fetch of modelFetchList as ProjectionMapValue<
-        Extract<E, { type: E['type'] }>,
-        Extract<RM, { type: RM['type'] }>
-      >[]) {
+      const modelFetchList = map[event.type as keyof typeof map] ?? []
+      for (const fetch of modelFetchList) {
         if (!fetch?.readModel) continue
         const modelType = fetch.readModel
 

--- a/src/event/fn/prefetch-read-model.ts
+++ b/src/event/fn/prefetch-read-model.ts
@@ -1,7 +1,7 @@
 import { v4 } from 'uuid'
-import type { ReadModelStore } from '../../types/adapter'
+import type { FilterCondition, ReadModelStore } from '../../types/adapter'
 import type { DomainEvent, ReadModel } from '../../types/core'
-import type { ProjectionMap } from '../../types/event'
+import type { ProjectionMap, ProjectionMapValue } from '../../types/event'
 import type { AppError, AsyncResult } from '../../types/utils'
 import { err, ok, toAsyncResult } from '../../utils/result'
 import { validateEvent } from '../helpers/validate-domain-event'
@@ -18,104 +18,75 @@ export function createPrefetchReadModel<E extends DomainEvent, RM extends ReadMo
       const validated = validateEvent(event)
       if (!validated.ok) return validated
 
-      const modelFetchList = map[event.type as keyof typeof map]
-      if (!modelFetchList || !Array.isArray(modelFetchList)) {
-        return ok({})
-      }
-
       const dict: Record<string, ReadModel> = {}
 
-      for (const fetch of modelFetchList) {
-        if (!fetch || typeof fetch !== 'object' || !fetch.readModel) continue
-
+      const modelFetchList = map[event.type as keyof typeof map]
+      for (const fetch of modelFetchList as ProjectionMapValue<
+        Extract<E, { type: E['type'] }>,
+        Extract<RM, { type: RM['type'] }>
+      >[]) {
+        if (!fetch?.readModel) continue
         const modelType = fetch.readModel
 
-        try {
-          if (fetch.where) {
-            const whereResult = fetch.where(event as Extract<E, { type: E['type'] }>)
-            // biome-ignore lint/suspicious/noExplicitAny: "filter is used to store the result of the where clause"
-            let filter: any
-
-            if (whereResult && typeof whereResult === 'object') {
-              if ('by' in whereResult && 'operator' in whereResult && 'value' in whereResult) {
-                filter = [whereResult]
-              } else {
-                filter = (
-                  Object.entries(whereResult) as [
-                    keyof ReadModel & string,
-                    ReadModel[keyof ReadModel]
-                  ][]
-                ).map(([by, value]) => ({ by, operator: 'eq' as const, value }))
-              }
-            }
-
-            const modelsResult = await toAsyncResult(() => store.findMany(modelType, { filter }))
-            if (!modelsResult.ok) {
-              return err({
-                code: 'READ_MODEL_FETCH_FAILED',
-                message: `Failed to fetch read models of type '${modelType}'`,
-                cause: modelsResult.error
-              })
-            }
-
-            for (const model of modelsResult.value) {
-              if (model?.id) {
-                const key = modelType + model.id
-                if (!dict[key]) {
-                  dict[key] = model
-                }
-              }
-            }
-
-            if (!modelsResult.value || modelsResult.value.length === 0) {
-              const placeholderModel = {
-                type: modelType,
-                id: v4()
-              }
-              const key = modelType + placeholderModel.id
-              if (!dict[key]) {
-                dict[key] = placeholderModel
-              }
-            }
-          } else {
-            if (!event.id?.value) continue
-
-            const modelResult = await toAsyncResult(() => store.findById(modelType, event.id.value))
-            if (!modelResult.ok) {
-              return err({
-                code: 'READ_MODEL_FETCH_FAILED',
-                message: `Failed to fetch read model of type '${modelType}' with id '${event.id.value}'`,
-                cause: modelResult.error
-              })
-            }
-
-            const model = modelResult.value
-            if (model?.id) {
-              const key = modelType + model.id
-              if (!dict[key]) {
-                dict[key] = model
-              }
-            } else {
-              const placeholderModel = {
-                type: modelType,
-                id: event.id?.value || 'unknown'
-              }
-              const key = modelType + placeholderModel.id
-              if (!dict[key]) {
-                dict[key] = placeholderModel
-              }
-            }
+        if (fetch.where) {
+          const filter = normalizeFilter(fetch.where(event as Extract<E, { type: E['type'] }>))
+          const res = await toAsyncResult(() => store.findMany(modelType, { filter }))
+          if (!res.ok) {
+            return err({
+              code: 'READ_MODEL_FETCH_FAILED',
+              message: `Failed to fetch read modelsss of type '${modelType}'`,
+              cause: res.error
+            })
           }
-        } catch (error) {
-          return err({
-            code: 'READ_MODEL_FETCH_FAILED',
-            message: `Unexpected error while fetching read model of type '${modelType}'`,
-            cause: error
-          })
+          if (!res.ok) return res
+
+          const models = res.value
+          if (models.length > 0) {
+            for (const m of models) if (m?.id) dict[modelType + m.id] ??= m
+          } else {
+            dict[modelType + v4()] ??= placeholder(modelType)
+          }
+        } else if (event.id?.value) {
+          const res = await toAsyncResult(() => store.findById(modelType, event.id.value))
+          if (!res.ok) {
+            return err({
+              code: 'READ_MODEL_FETCH_FAILED',
+              message: `Failed to fetch read model of type '${modelType}' with id '${event.id.value}'`,
+              cause: res.error
+            })
+          }
+
+          const model = res.value
+          dict[modelType + (model?.id ?? event.id.value)] ??=
+            model ?? placeholder(modelType, event.id.value)
         }
       }
 
       return ok(dict)
     }
   }
+}
+
+/**
+ * Normalizes where clause results into FilterCondition[] format
+ * Handles both direct FilterCondition objects and plain object mappings
+ */
+function normalizeFilter(whereResult: unknown): FilterCondition<ReadModel>[] | undefined {
+  if (!whereResult || typeof whereResult !== 'object') return undefined
+  if ('by' in whereResult && 'operator' in whereResult && 'value' in whereResult) {
+    return [whereResult as FilterCondition<ReadModel>]
+  }
+  return Object.entries(whereResult as Record<string, unknown>).map(([by, value]) => ({
+    by,
+    operator: 'eq' as const,
+    value
+  })) as FilterCondition<ReadModel>[]
+}
+
+/**
+ * Creates a placeholder read model when no actual model is found
+ * Uses provided ID or generates a new UUID
+ */
+function placeholder(modelType: string, id?: string): ReadModel {
+  return { type: modelType, id: id ?? v4() } as ReadModel
 }

--- a/src/types/event/projection-fn.ts
+++ b/src/types/event/projection-fn.ts
@@ -7,7 +7,7 @@ export type ProjectionCtx = {
 
 export type ProjectionMode = 'create' | 'update' | 'upsert'
 
-type ProjectionMapValue<E extends DomainEvent, RM extends ReadModel> = {
+export type ProjectionMapValue<E extends DomainEvent, RM extends ReadModel> = {
   readModel: RM['type']
   where?: (e: E) => FilterCondition<RM>
   mode?: ProjectionMode


### PR DESCRIPTION

## Summary

enhance prefetch-read-model and projection type handling

## Changes

- Added FilterCondition type import in prefetch-read-model.ts
- Updated prefetch-read-model to normalize filter conditions and create placeholders
- Made ProjectionMapValue type export in projection-fn.ts
- Improved error handling and model fetching logic in prefetch-read-model


## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests executed
- [x] Integration tests executed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors prefetch-read-model to normalize filters, streamline fetch/placeholder logic, and exports ProjectionMapValue.
> 
> - **Event handling**:
>   - **Prefetch read model** (`src/event/fn/prefetch-read-model.ts`):
>     - Normalize `where` clause to `FilterCondition[]` via `normalizeFilter`.
>     - Streamline fetching: consolidated `findMany`/`findById`, deduplicated dict insertion, and added `placeholder` helper.
>     - Default empty `modelFetchList`; simplified guards and returns; refined error handling/messages.
>     - Import `FilterCondition` type.
> - **Types**:
>   - Export `ProjectionMapValue` in `src/types/event/projection-fn.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b44293b3af44c7e5304439f3708ae62a396c120. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->