### PR TITLE
refactor: update test descriptions for clarity

### DIFF
--- a/tests/command/aggregate-builder.test.ts
+++ b/tests/command/aggregate-builder.test.ts
@@ -17,7 +17,7 @@ type TestEvent =
   | { type: 'updated'; id: AggregateId<'test'>; payload: { value: number } }
   | { type: 'deactivated'; id: AggregateId<'test'> }
 
-describe('aggregate-builder', () => {
+describe('[command] aggregate builder', () => {
   describe('createAggregate', () => {
     test('creates aggregate builder instance', () => {
       // Arrange & Act

--- a/tests/command/command-bus.test.ts
+++ b/tests/command/command-bus.test.ts
@@ -6,7 +6,7 @@ import type { AggregateId, Command } from '../../src/types/core'
 import type { CommandHandler, CommandHandlerMiddleware } from '../../src/types/framework'
 import { counter } from '../fixtures/counter-app/features/counter/counter-aggregate'
 
-describe('command-bus', () => {
+describe('[command] command bus', () => {
   describe('createCommandBus', () => {
     test('creates command bus with minimal configuration', () => {
       // Arrange

--- a/tests/command/command-handler.test.ts
+++ b/tests/command/command-handler.test.ts
@@ -5,7 +5,7 @@ import { zeroId } from '../../src/command/helpers/aggregate-id'
 import { counter } from '../fixtures'
 import type { CounterCommand } from '../fixtures/counter-app/features/counter/types'
 
-describe('command-handler', () => {
+describe('[command] command handler', () => {
   describe('createCommandHandlerFactory', () => {
     describe('new aggregate creation flow', () => {
       test('creates new aggregate when no events stored', async () => {

--- a/tests/command/helpers/aggregate-id.test.ts
+++ b/tests/command/helpers/aggregate-id.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../src/command/helpers/aggregate-id'
 import type { AggregateId } from '../../../src/types/core'
 
-describe('aggregate-id', () => {
+describe('[command] aggregate id', () => {
   describe('id', () => {
     test('creates aggregate ID with specified type and value', () => {
       // Arrange

--- a/tests/command/helpers/validate-command.test.ts
+++ b/tests/command/helpers/validate-command.test.ts
@@ -3,7 +3,7 @@ import { id, zeroId } from '../../../src/command/helpers/aggregate-id'
 import { validateCommand } from '../../../src/command/helpers/validate-command'
 import type { AggregateId, Command } from '../../../src/types/core'
 
-describe('validate-command', () => {
+describe('[command] validate command', () => {
   describe('validateCommand', () => {
     test('returns success for valid command with payload', () => {
       // Arrange

--- a/tests/command/mapper/map-to-accepts-fn.test.ts
+++ b/tests/command/mapper/map-to-accepts-fn.test.ts
@@ -24,7 +24,7 @@ type TestEvent =
   | { type: 'activated'; id: AggregateId }
   | { type: 'deactivated'; id: AggregateId }
 
-describe('map-to-accepts-fn', () => {
+describe('[command] map to accepts fn', () => {
   describe('mapToAcceptsCommandFn', () => {
     test('accepts all command and state combinations when empty map is provided', () => {
       const emptyMap = {} as EventDeciderMap<TestState, TestCommand>

--- a/tests/command/mapper/map-to-event-decider-fn.test.ts
+++ b/tests/command/mapper/map-to-event-decider-fn.test.ts
@@ -34,7 +34,7 @@ const testDeciders: EventDecider<TestState, TestCommand, TestEvent> = {
   })
 }
 
-describe('map-to-event-decider-fn', () => {
+describe('[command] map to event decider fn', () => {
   describe('mapToEventDeciderFn', () => {
     test('converts EventDecider object to EventDeciderFn', () => {
       // Arrange & Act

--- a/tests/command/mapper/map-to-reducer-fn.test.ts
+++ b/tests/command/mapper/map-to-reducer-fn.test.ts
@@ -12,7 +12,7 @@ type TestEvent =
   | { type: 'updated'; id: AggregateId<'test'>; payload: { value: number } }
   | { type: 'deactivated'; id: AggregateId<'test'> }
 
-describe('map-to-reducer-fn', () => {
+describe('[command] map to reducer fn', () => {
   describe('mapToReducerFn', () => {
     test('converts Reducer object to ReducerFn', () => {
       // Arrange

--- a/tests/event/event-bus.test.ts
+++ b/tests/event/event-bus.test.ts
@@ -8,7 +8,7 @@ import type { EventReactor } from '../../src/types/event'
 import type { CounterEvent } from '../fixtures/counter-app/features/counter'
 import { counterReactor } from '../fixtures/counter-app/features/counter'
 
-describe('[event] event-bus', () => {
+describe('[event] event bus', () => {
   describe('createEventBus', () => {
     test('creates event bus with dependencies and reactors', () => {
       // Arrange

--- a/tests/event/event-handler.test.ts
+++ b/tests/event/event-handler.test.ts
@@ -13,7 +13,7 @@ import type {
   CounterReadModels
 } from '../fixtures/counter-app/features/counter/types'
 
-describe('[event] event-handler', () => {
+describe('[event] event handler', () => {
   describe('createEventHandlers', () => {
     test('processes events successfully when all operations succeed', async () => {
       // Arrange

--- a/tests/event/event-reactor-builder.test.ts
+++ b/tests/event/event-reactor-builder.test.ts
@@ -23,7 +23,7 @@ type TestReadModel = ReadModel & {
   updatedAt: Date
 }
 
-describe('[event] event-reactor-builder', () => {
+describe('[event] event reactor builder', () => {
   describe('createEventReactor', () => {
     test('creates event reactor builder instance', () => {
       // Arrange & Act

--- a/tests/event/fn/dispatch-event.test.ts
+++ b/tests/event/fn/dispatch-event.test.ts
@@ -8,7 +8,7 @@ import type {
   CounterEvent
 } from '../../fixtures/counter-app/features/counter/types'
 
-describe('[event] dispatch-event', () => {
+describe('[event] dispatch event', () => {
   describe('createDispatchEventFnFactory', () => {
     test('returns ok when policy returns no command', async () => {
       // Arrange

--- a/tests/event/fn/prefetch-read-model.test.ts
+++ b/tests/event/fn/prefetch-read-model.test.ts
@@ -9,7 +9,7 @@ import type {
   CounterReadModel
 } from '../../fixtures/counter-app/shared/readmodel'
 
-describe('[event] prefetch-read-model', () => {
+describe('[event] prefetch read model', () => {
   describe('createPrefetchReadModel', () => {
     test('returns error when event is invalid', async () => {
       // Arrange

--- a/tests/event/fn/project-event.test.ts
+++ b/tests/event/fn/project-event.test.ts
@@ -7,7 +7,7 @@ import type { Projection, ProjectionMap } from '../../../src/types/event'
 import type { CounterEvent } from '../../fixtures/counter-app/features/counter/types'
 import type { CounterReadModel } from '../../fixtures/counter-app/shared/readmodel'
 
-describe('[event] project-event', () => {
+describe('[event] project event', () => {
   describe('createProjectEventFnFactory', () => {
     test('returns empty dict when no read models provided', async () => {
       // Arrange

--- a/tests/event/fn/save-read-model.test.ts
+++ b/tests/event/fn/save-read-model.test.ts
@@ -3,7 +3,7 @@ import { ReadModelStoreInMemory } from '../../../src/adapter/read-model-store-in
 import { createSaveReadModel } from '../../../src/event/fn/save-read-model'
 import type { CounterReadModel } from '../../fixtures/counter-app/shared/readmodel'
 
-describe('[event] save-read-model', () => {
+describe('[event] save read model', () => {
   describe('createSaveReadModel', () => {
     test('returns success when no read models provided', async () => {
       // Arrange

--- a/tests/event/helpers/validate-domain-event.test.ts
+++ b/tests/event/helpers/validate-domain-event.test.ts
@@ -3,7 +3,7 @@ import { id, zeroId } from '../../../src/command/helpers/aggregate-id'
 import { validateEvent } from '../../../src/event/helpers/validate-domain-event'
 import type { AggregateId, DomainEvent } from '../../../src/types/core'
 
-describe('[event] validate-domain-event', () => {
+describe('[event] validate domain event', () => {
   describe('validateEvent', () => {
     test('returns success for valid event with payload', () => {
       // Arrange

--- a/tests/event/mapper/map-to-projection-fn.test.ts
+++ b/tests/event/mapper/map-to-projection-fn.test.ts
@@ -16,7 +16,7 @@ type TestReadModel = ReadModel & {
   status: 'active' | 'inactive'
 }
 
-describe('[event] map-to-projection-fn', () => {
+describe('[event] map to projection fn', () => {
   describe('mapProjectionToFn', () => {
     test('returns original read model when event type not found in projection', () => {
       // Arrange

--- a/tests/fixtures/counter-app/features/counter/counter-aggregate.test.ts
+++ b/tests/fixtures/counter-app/features/counter/counter-aggregate.test.ts
@@ -3,7 +3,7 @@ import { zeroId } from '../../../../../src/command/helpers/aggregate-id'
 import { aggregateFixture } from '../../../../../src/fake/aggregate-fixture'
 import { counter } from './counter-aggregate'
 
-describe('[fixtures] counter app', () => {
+describe('[fixtures] counter aggregate', () => {
   const counterId = zeroId('counter')
 
   describe('counter aggregate: create command', () => {

--- a/tests/fixtures/counter-app/features/counter/counter-reactor.test.ts
+++ b/tests/fixtures/counter-app/features/counter/counter-reactor.test.ts
@@ -50,7 +50,7 @@ const projection: Projection<CounterEvent, CounterReadModels, typeof projectionM
   }
 }
 
-describe('[counter] counter reactor (no Map)', () => {
+describe('[fixtures] counter reactor', () => {
   const counterId = zeroId('counter')
 
   test('handles created event and creates counterReadModel', () => {

--- a/tests/fixtures/counter-app/features/counter2/counter2-aggregate.test.ts
+++ b/tests/fixtures/counter-app/features/counter2/counter2-aggregate.test.ts
@@ -3,7 +3,7 @@ import { zeroId } from '../../../../../src/command/helpers/aggregate-id'
 import { aggregateFixture } from '../../../../../src/fake/aggregate-fixture'
 import { counter2 } from './counter2-aggregate'
 
-describe('[fixtures] counter2 app', () => {
+describe('[fixtures] counter2 aggregate', () => {
   const counterId = zeroId('counter')
 
   describe('counter2 aggregate: create command', () => {

--- a/tests/fixtures/counter-app/features/counter2/counter2-reactor.test.ts
+++ b/tests/fixtures/counter-app/features/counter2/counter2-reactor.test.ts
@@ -3,7 +3,7 @@ import { zeroId } from '../../../../../src'
 import { reactorFixture } from '../../../../../src/fake/event-reactor-fixture'
 import { counterReactor } from './counter2-reactor'
 
-describe('[counter2] counter reactor (no Map)', () => {
+describe('[fixtures] counter2 reactor', () => {
   const counterId = zeroId('counter')
 
   test('handles created event and creates counterReadModel', () => {

--- a/tests/query/fn/resolve-read-model.test.ts
+++ b/tests/query/fn/resolve-read-model.test.ts
@@ -5,7 +5,7 @@ import type { ResolverContext, ResolverFn } from '../../../src/types/query/resol
 import type { CounterQuery, CounterQueryResult } from '../../fixtures/counter-app/features/counter'
 import type { CounterReadModel } from '../../fixtures/counter-app/shared/readmodel'
 
-describe('resolve-read-models', () => {
+describe('[query] resolve read model', () => {
   describe('createResolveReadModelFnFactory', () => {
     test('should return a function when resolver is provided', () => {
       // Arrange

--- a/tests/query/helpers/validate-query.test.ts
+++ b/tests/query/helpers/validate-query.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { validateQuery } from '../../../src/query/helpers/validate-query'
 import type { Query } from '../../../src/types/core/query'
 
-describe('[query] validate query helper', () => {
+describe('[query] validate query', () => {
   describe('validateQuery', () => {
     test('returns success when query has valid type', () => {
       // Arrange

--- a/tests/query/query-bus.test.ts
+++ b/tests/query/query-bus.test.ts
@@ -10,7 +10,7 @@ import type {
 } from '../fixtures/counter-app/features/counter2/types'
 import type { CounterReadModel } from '../fixtures/counter-app/shared/readmodel'
 
-describe('query-bus', () => {
+describe('[query] query bus', () => {
   describe('createQueryBus', () => {
     test('should return a function when created with minimal configuration', () => {
       // Arrange

--- a/tests/query/query-handler.test.ts
+++ b/tests/query/query-handler.test.ts
@@ -5,7 +5,7 @@ import { counterQuerySource } from '../fixtures/counter-app/features/counter'
 import type { CounterQuery } from '../fixtures/counter-app/features/counter2/types'
 import type { CounterReadModel } from '../fixtures/counter-app/shared/readmodel'
 
-describe('query-handler', () => {
+describe('[query] query handler', () => {
   describe('createQueryHandlers', () => {
     test('should handle single item query', async () => {
       // Arrange

--- a/tests/query/query-source-builder.test.ts
+++ b/tests/query/query-source-builder.test.ts
@@ -30,7 +30,7 @@ type CounterMultiQueryResult =
       total: number
     }
 
-describe('query-source-builder', () => {
+describe('[query] query source builder', () => {
   describe('createQuerySource', () => {
     test('should build valid query source with all required methods', async () => {
       // Arrange

--- a/tests/utils/result.test.ts
+++ b/tests/utils/result.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { err, ok, toAsyncResult, toResult } from '../../src'
 import type { Ok } from '../../src/types/utils'
 
-describe('[utils] result utility functions', () => {
+describe('[utils] result', () => {
   describe('ok', () => {
     test('creates successful result with string value', () => {
       // Arrange


### PR DESCRIPTION
## Summary

update test descriptions for clarity

## Changes

- Changed test suite descriptions to include '[command]' prefix for better categorization
- Updated descriptions in aggregate-builder, command-bus, command-handler, aggregate-id, validate-command, and various mapper tests
- Ensured consistency in test naming conventions across command-related tests

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests executed
- [x] Integration tests executed
